### PR TITLE
repo: github: workflows: remove publish-documentation path dependency

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -11,8 +11,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'doc/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Basend on https://docs.github.com/en/actions/using-workflows ducumentation:

When using the push and pull_request events, you can configure a workflow to run based on what file paths are changed.

But we want to generate documentation each time any file changes.