### PR TITLE
samples: fuel_gauge: align battery temperature calculation

### DIFF
--- a/drivers/npmx/npmx_shell.c
+++ b/drivers/npmx/npmx_shell.c
@@ -773,7 +773,7 @@ static int cmd_ntc_resistance_set(const struct shell *shell, size_t argc, char *
 
 	err_code = func(charger_instance, resistance);
 	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Success: %d Ohms.", resistance);
+		shell_print(shell, "Success: %d Ohm.", resistance);
 	} else {
 		shell_error(shell, "Error: unable to set NTC resistance value.");
 	}
@@ -801,7 +801,7 @@ static int cmd_ntc_resistance_get(const struct shell *shell, size_t argc, char *
 	npmx_error_t err_code = func(charger_instance, &resistance);
 
 	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Value: %d Ohms.", resistance);
+		shell_print(shell, "Value: %d Ohm.", resistance);
 	} else {
 		shell_error(shell, "Error: unable to read NTC resistance value.");
 	}
@@ -2670,7 +2670,14 @@ static int adc_ntc_set(const struct shell *shell, size_t argc, char **argv,
 
 	err_code = npmx_adc_ntc_config_set(adc_instance, &ntc_config);
 	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Success: %u.", config_val);
+		switch (config_type) {
+		case ADC_NTC_CONFIG_PARAM_TYPE:
+			shell_print(shell, "Success: %u Ohm.", config_val);
+			break;
+		case ADC_NTC_CONFIG_PARAM_BETA:
+			shell_print(shell, "Success: %u.", config_val);
+			break;
+		}
 	} else {
 		shell_error(shell, "Error: unable to set ADC NTC value.");
 	}

--- a/samples/charger_and_events/src/main.c
+++ b/samples/charger_and_events/src/main.c
@@ -367,8 +367,10 @@ void main(void)
 	npmx_core_event_interrupt_enable(npmx_instance, NPMX_EVENT_GROUP_ADC,
 					 NPMX_EVENT_GROUP_ADC_BAT_READY_MASK);
 
-	/* Set NTC type for ADC measurements. */
-	npmx_adc_ntc_set(npmx_adc_get(npmx_instance, 0), NPMX_ADC_NTC_TYPE_10_K);
+	npmx_adc_ntc_config_t ntc_config = { .type = NPMX_ADC_NTC_TYPE_10_K, .beta = 0 };
+
+	/* Set thermistor type for ADC measurements. Beta value is not used. */
+	npmx_adc_ntc_config_set(npmx_adc_get(npmx_instance, 0), &ntc_config);
 
 	/* Enable ADC auto measurements every ~1 s (default). */
 	npmx_adc_config_t config = { .vbat_auto = true, .vbat_burst = false };

--- a/samples/fuel_gauge/src/fuel_gauge.c
+++ b/samples/fuel_gauge/src/fuel_gauge.c
@@ -45,12 +45,8 @@ static int read_sensors(npmx_instance_t *const p_pm, float *voltage, float *curr
 	/* Convert current in milliamperes to current in amperes. */
 	*current = (float)meas.values[NPMX_ADC_MEAS_VBAT2_IBAT] / 1000.0f;
 
-	/* Calculate temperature based on the NTC resistance value. Equations taken from datasheet. */
-	int32_t code = (meas.values[NPMX_ADC_MEAS_NTC] * NPMX_PERIPH_ADC_BITS_RESOLUTION) /
-		       (CONFIG_THERMISTOR_RESISTANCE + meas.values[NPMX_ADC_MEAS_NTC]);
-	float log_result = log(((float)NPMX_PERIPH_ADC_BITS_RESOLUTION / (float)code) - 1);
-	float inv_temp_k = (1.f / 298.15f) - (log_result / (float)CONFIG_THERMISTOR_BETA);
-	*temp = (1.f / inv_temp_k) - 273.15f;
+	/* Convert temperature in millidegrees Celsius to temperature in Celsius */
+	*temp = (float)meas.values[NPMX_ADC_MEAS_BAT_TEMP] / 1000.0f;
 
 	/* Convert voltage in millivolts to voltage in volts. */
 	*voltage = (float)meas.values[NPMX_ADC_MEAS_VBAT] / 1000.0f;

--- a/samples/fuel_gauge/src/main.c
+++ b/samples/fuel_gauge/src/main.c
@@ -84,8 +84,12 @@ void main(void)
 	/* Apply current limit. */
 	npmx_vbusin_task_trigger(vbusin_instance, NPMX_VBUSIN_TASK_APPLY_CURRENT_LIMIT);
 
-	/* Set NTC type for ADC measurements. */
-	npmx_adc_ntc_set(adc_instance, npmx_adc_ntc_type_convert(CONFIG_THERMISTOR_RESISTANCE));
+	npmx_adc_ntc_config_t ntc_config = { .type = npmx_adc_ntc_type_convert(
+						     CONFIG_THERMISTOR_RESISTANCE),
+					     .beta = CONFIG_THERMISTOR_BETA };
+
+	/* Set thermistor type and NTC beta value for ADC measurements. */
+	npmx_adc_ntc_config_set(adc_instance, &ntc_config);
 
 	/* Enable auto measurement of the battery current after the battery voltage measurement. */
 	npmx_adc_ibat_meas_enable_set(adc_instance, true);

--- a/samples/simple/src/main.c
+++ b/samples/simple/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2022-2023 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -94,8 +94,10 @@ void main(void)
 	npmx_led_mode_set(npmx_led_get(npmx_instance, 1), NPMX_LED_MODE_ERROR);
 	npmx_led_mode_set(npmx_led_get(npmx_instance, 2), NPMX_LED_MODE_NOTUSED);
 
-	/* Set NTC type for ADC measurements. */
-	npmx_adc_ntc_set(npmx_adc_get(npmx_instance, 0), NPMX_ADC_NTC_TYPE_10_K);
+	npmx_adc_ntc_config_t ntc_config = { .type = NPMX_ADC_NTC_TYPE_10_K, .beta = 0 };
+
+	/* Set thermistor type for charger module NTC. Beta value is not used. */
+	npmx_adc_ntc_config_set(npmx_adc_get(npmx_instance, 0), &ntc_config);
 
 	while (1) {
 		k_sleep(K_FOREVER);

--- a/west.yml
+++ b/west.yml
@@ -21,7 +21,7 @@ manifest:
   projects:
     - name: npmx
       path: modules/npmx
-      revision: 97bde816d620f32ea26c62319a3553b133540ee6
+      revision: 2bfa5c08ccc578c64f71ab3f51659d8e71008895
     - name: zephyr
       revision: v3.3.0
       import: true


### PR DESCRIPTION
In this PR, NTC type config set was changed from `npmx adc ntc set ntc_10k` to `npmx adc ntc type set 10000` which is similar to all other functions.
`npmx adc ntc get` -> `npmx adc ntc type get`
Also, the command `npmx adc ntc beta 4000` was implemented.