### PR TITLE
drivers: npmx: shell: clean code

### DIFF
--- a/drivers/npmx/npmx_shell.c
+++ b/drivers/npmx/npmx_shell.c
@@ -16,6 +16,12 @@
 /** @brief Max supported number of shell arguments. */
 #define SHELL_ARG_MAX_COUNT 3U
 
+/** @brief NTC thermistor configuration parameter. */
+typedef enum {
+	ADC_NTC_CONFIG_PARAM_TYPE, /* Battery NTC type. */
+	ADC_NTC_CONFIG_PARAM_BETA /* Battery NTC beta value. */
+} adc_ntc_config_param_t;
+
 /** @brief GPIO configuration type. */
 typedef enum {
 	GPIO_CONFIG_TYPE_MODE, /* GPIO mode. */
@@ -57,12 +63,6 @@ typedef enum {
 	LDSW_SOFT_START_TYPE_ENABLE, /* Soft-start enable. */
 	LDSW_SOFT_START_TYPE_CURRENT /* Soft-start current. */
 } ldsw_soft_start_config_type_t;
-
-/** @brief NTC thermistor configuration parameter. */
-typedef enum {
-	ADC_NTC_CONFIG_PARAM_TYPE, /* Battery NTC type. */
-	ADC_NTC_CONFIG_PARAM_BETA /* Battery NTC beta value. */
-} adc_ntc_config_param_t;
 
 /** @brief Supported shell argument types. */
 typedef enum {
@@ -295,6 +295,38 @@ static bool check_instance_index(const struct shell *shell, const char *instance
 	return true;
 }
 
+static npmx_adc_t *adc_instance_get(const struct shell *shell)
+{
+	npmx_instance_t *npmx_instance = npmx_instance_get(shell);
+
+	return npmx_instance ? npmx_adc_get(npmx_instance, 0) : NULL;
+}
+
+static npmx_charger_t *charger_instance_get(const struct shell *shell)
+{
+	npmx_instance_t *npmx_instance = npmx_instance_get(shell);
+
+	return npmx_instance ? npmx_charger_get(npmx_instance, 0) : NULL;
+}
+
+static bool charger_disabled_check(const struct shell *shell, npmx_charger_t *charger_instance,
+				   const char *help)
+{
+	uint32_t modules_mask;
+	npmx_error_t err_code = npmx_charger_module_get(charger_instance, &modules_mask);
+
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "charger module status");
+		return false;
+	}
+
+	if ((modules_mask & NPMX_CHARGER_MODULE_CHARGER_MASK) != 0) {
+		shell_error(shell, "Error: charger must be disabled to set %s.", help);
+		return false;
+	}
+	return true;
+}
+
 static bool check_pin_configuration_correctness(const struct shell *shell, int8_t gpio_idx)
 {
 	int8_t pmic_int_pin = (int8_t)npmx_driver_int_pin_get(pmic_dev);
@@ -311,6 +343,286 @@ static bool check_pin_configuration_correctness(const struct shell *shell, int8_
 	}
 
 	return true;
+}
+
+static int cmd_adc_meas_vbat_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	npmx_adc_t *adc_instance = adc_instance_get(shell);
+	if (adc_instance == NULL) {
+		return 0;
+	}
+
+	npmx_error_t err_code = npmx_adc_task_trigger(adc_instance, NPMX_ADC_TASK_SINGLE_SHOT_VBAT);
+	if (!check_error_code(shell, err_code)) {
+		shell_error(shell, "Error: unable to trigger the measurement.");
+		return 0;
+	}
+
+	int32_t voltage_mv;
+	bool meas_get = false;
+	while (!meas_get) {
+		err_code = npmx_adc_meas_check(adc_instance, NPMX_ADC_MEAS_VBAT, &meas_get);
+		if (!check_error_code(shell, err_code)) {
+			print_get_error(shell, "measurement status");
+			return 0;
+		}
+	}
+
+	err_code = npmx_adc_meas_get(adc_instance, NPMX_ADC_MEAS_VBAT, &voltage_mv);
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "measurement");
+		return 0;
+	}
+
+	print_value(shell, voltage_mv, UNIT_TYPE_MILLIVOLT);
+	return 0;
+}
+
+static int adc_ntc_set(const struct shell *shell, size_t argc, char **argv,
+		       adc_ntc_config_param_t config_type)
+{
+	char *config_name;
+	switch (config_type) {
+	case ADC_NTC_CONFIG_PARAM_TYPE:
+		config_name = "NTC type";
+		break;
+	case ADC_NTC_CONFIG_PARAM_BETA:
+		config_name = "NTC beta";
+		break;
+	}
+
+	args_info_t args_info = { .expected_args = 1,
+				  .arg = {
+					  [0] = { SHELL_ARG_TYPE_UINT32_VALUE, config_name },
+				  } };
+	if (!arguments_check(shell, argc, argv, &args_info)) {
+		return 0;
+	}
+
+	uint32_t config_value = args_info.arg[0].result.uvalue;
+	if ((config_type == ADC_NTC_CONFIG_PARAM_BETA) && (config_value == 0)) {
+		shell_error(shell, "Error: beta cannot be equal to zero.");
+		return 0;
+	}
+
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
+		return 0;
+	}
+
+	if (!charger_disabled_check(shell, charger_instance, "NTC config")) {
+		return 0;
+	}
+
+	npmx_adc_t *adc_instance = adc_instance_get(shell);
+	if (adc_instance == NULL) {
+		return 0;
+	}
+
+	npmx_adc_ntc_config_t ntc_config;
+	npmx_error_t err_code = npmx_adc_ntc_config_get(adc_instance, &ntc_config);
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "NTC config");
+		return 0;
+	}
+
+	bool recalculate_temps =
+		(config_type == ADC_NTC_CONFIG_PARAM_BETA &&
+		 ntc_config.type != NPMX_ADC_NTC_TYPE_HI_Z && ntc_config.beta != 0);
+	int16_t temp_cool, temp_cold, temp_warm, temp_hot;
+	if (recalculate_temps) {
+		err_code = npmx_charger_cold_temperature_get(charger_instance, &temp_cold);
+		if (!check_error_code(shell, err_code)) {
+			print_get_error(shell, "previous NTC cold treshold");
+			return 0;
+		}
+
+		err_code = npmx_charger_cool_temperature_get(charger_instance, &temp_cool);
+		if (!check_error_code(shell, err_code)) {
+			print_get_error(shell, "previous NTC cool treshold");
+			return 0;
+		}
+
+		err_code = npmx_charger_warm_temperature_get(charger_instance, &temp_warm);
+		if (!check_error_code(shell, err_code)) {
+			print_get_error(shell, "previous NTC warm treshold");
+			return 0;
+		}
+
+		err_code = npmx_charger_hot_temperature_get(charger_instance, &temp_hot);
+		if (!check_error_code(shell, err_code)) {
+			print_get_error(shell, "previous NTC hot treshold");
+			return 0;
+		}
+	}
+
+	switch (config_type) {
+	case ADC_NTC_CONFIG_PARAM_TYPE:
+		ntc_config.type = npmx_adc_ntc_type_convert(config_value);
+		if (ntc_config.type == NPMX_ADC_NTC_TYPE_INVALID) {
+			print_convert_error(shell, "resistance", "NTC type");
+			return 0;
+		}
+
+		uint32_t modules_mask;
+		if (ntc_config.type == NPMX_ADC_NTC_TYPE_HI_Z) {
+			err_code = npmx_charger_module_get(charger_instance, &modules_mask);
+			if (!check_error_code(shell, err_code)) {
+				print_get_error(shell, "NTC limits module status");
+				return 0;
+			}
+
+			if ((modules_mask & NPMX_CHARGER_MODULE_NTC_LIMITS_MASK) == 0) {
+				/* NTC limits module is already disabled. */
+				break;
+			}
+
+			err_code = npmx_charger_module_disable_set(
+				charger_instance, NPMX_CHARGER_MODULE_NTC_LIMITS_MASK);
+			if (!check_error_code(shell, err_code)) {
+				shell_error(shell,
+					    "Error: unable to disable the NTC limits module.");
+				return 0;
+			}
+
+			shell_info(shell, "Info: the NTC limits module has been disabled.");
+			shell_info(shell, "      To re-enable, change the NTC type to != 0.");
+		} else {
+			err_code = npmx_charger_module_get(charger_instance, &modules_mask);
+			if (!check_error_code(shell, err_code)) {
+				print_get_error(shell, "NTC limits module status");
+				return 0;
+			}
+
+			if ((modules_mask & NPMX_CHARGER_MODULE_NTC_LIMITS_MASK) > 0) {
+				/* NTC limits module is already enabled. */
+				break;
+			}
+
+			err_code = npmx_charger_module_enable_set(
+				charger_instance, NPMX_CHARGER_MODULE_NTC_LIMITS_MASK);
+			if (!check_error_code(shell, err_code)) {
+				shell_error(shell,
+					    "Error: unable to enable the NTC limits module.");
+				return 0;
+			}
+
+			shell_info(shell, "Info: the NTC limits module has been enabled.");
+		}
+		break;
+
+	case ADC_NTC_CONFIG_PARAM_BETA:
+		ntc_config.beta = config_value;
+		break;
+	}
+
+	err_code = npmx_adc_ntc_config_set(adc_instance, &ntc_config);
+	if (!check_error_code(shell, err_code)) {
+		print_set_error(shell, "NTC config");
+		return 0;
+	}
+
+	switch (config_type) {
+	case ADC_NTC_CONFIG_PARAM_TYPE:
+		print_success(shell, config_value, UNIT_TYPE_OHM);
+		break;
+	case ADC_NTC_CONFIG_PARAM_BETA:
+		print_success(shell, config_value, UNIT_TYPE_NONE);
+
+		if (!recalculate_temps) {
+			break;
+		}
+
+		/* Recalculate threshold temperatures. */
+		err_code = npmx_charger_cold_temperature_set(charger_instance, temp_cold);
+		if (!check_error_code(shell, err_code)) {
+			print_set_error(shell, "new NTC cold treshold");
+			break;
+		}
+
+		err_code = npmx_charger_cool_temperature_set(charger_instance, temp_cool);
+		if (!check_error_code(shell, err_code)) {
+			print_set_error(shell, "new NTC cool treshold");
+			break;
+		}
+
+		err_code = npmx_charger_warm_temperature_set(charger_instance, temp_warm);
+		if (!check_error_code(shell, err_code)) {
+			print_set_error(shell, "new NTC warm treshold");
+			break;
+		}
+
+		err_code = npmx_charger_hot_temperature_set(charger_instance, temp_hot);
+		if (!check_error_code(shell, err_code)) {
+			print_set_error(shell, "new NTC hot treshold");
+			break;
+		}
+		shell_info(shell, "Info: NTC thresholds recalculated successfully.");
+
+		break;
+	}
+
+	return 0;
+}
+
+static int adc_ntc_get(const struct shell *shell, adc_ntc_config_param_t config_type)
+{
+	npmx_adc_t *adc_instance = adc_instance_get(shell);
+	if (adc_instance == NULL) {
+		return 0;
+	}
+
+	npmx_adc_ntc_config_t ntc_config;
+	npmx_error_t err_code = npmx_adc_ntc_config_get(adc_instance, &ntc_config);
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "NTC config");
+		return 0;
+	}
+
+	switch (config_type) {
+	case ADC_NTC_CONFIG_PARAM_TYPE:
+		uint32_t config_value;
+		if (!npmx_adc_ntc_type_convert_to_ohms(ntc_config.type, &config_value)) {
+			print_convert_error(shell, "NTC type", "resistance");
+			return 0;
+		}
+		print_value(shell, config_value, UNIT_TYPE_OHM);
+		break;
+	case ADC_NTC_CONFIG_PARAM_BETA:
+		print_value(shell, ntc_config.beta, UNIT_TYPE_NONE);
+		break;
+	}
+
+	return 0;
+}
+
+static int cmd_adc_ntc_beta_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return adc_ntc_set(shell, argc, argv, ADC_NTC_CONFIG_PARAM_BETA);
+}
+
+static int cmd_adc_ntc_beta_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return adc_ntc_get(shell, ADC_NTC_CONFIG_PARAM_BETA);
+}
+
+static int cmd_adc_ntc_type_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return adc_ntc_set(shell, argc, argv, ADC_NTC_CONFIG_PARAM_TYPE);
+}
+
+static int cmd_adc_ntc_type_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return adc_ntc_get(shell, ADC_NTC_CONFIG_PARAM_TYPE);
 }
 
 static int cmd_charger_termination_voltage_get(
@@ -3124,292 +3436,6 @@ static int cmd_gpio_debounce_set(const struct shell *shell, size_t argc, char **
 	return gpio_config_set(shell, argc, argv, GPIO_CONFIG_TYPE_DEBOUNCE);
 }
 
-static int adc_ntc_get(const struct shell *shell, size_t argc, char **argv,
-		       adc_ntc_config_param_t config_type)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	npmx_adc_t *adc_instance = npmx_adc_get(npmx_instance, 0);
-
-	npmx_adc_ntc_config_t ntc_config;
-	npmx_error_t err_code = npmx_adc_ntc_config_get(adc_instance, &ntc_config);
-
-	if (check_error_code(shell, err_code)) {
-		switch (config_type) {
-		case ADC_NTC_CONFIG_PARAM_TYPE:
-			uint32_t config_value;
-			if (!npmx_adc_ntc_type_convert_to_ohms(ntc_config.type, &config_value)) {
-				shell_error(shell,
-					    "Error: unable to convert NTC type to resistance.");
-				return 0;
-			}
-			shell_print(shell, "Value: %u Ohm.", config_value);
-			break;
-		case ADC_NTC_CONFIG_PARAM_BETA:
-			shell_print(shell, "Value: %u.", ntc_config.beta);
-			break;
-		}
-	} else {
-		shell_error(shell, "Error: unable to read ADC NTC config value.");
-	}
-
-	return 0;
-}
-
-static int adc_ntc_set(const struct shell *shell, size_t argc, char **argv,
-		       adc_ntc_config_param_t config_type)
-{
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	if (argc < 2) {
-		shell_error(shell, "Error: missing config value.");
-		return 0;
-	}
-
-	int err = 0;
-	uint32_t config_val = shell_strtoul(argv[1], 0, &err);
-	if (err != 0) {
-		shell_error(shell, "Error: config has to be an integer.");
-		return 0;
-	}
-
-	if (config_type == ADC_NTC_CONFIG_PARAM_BETA && config_val == 0) {
-		shell_error(shell, "Error: beta cannot be equal to zero.");
-		return 0;
-	}
-
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-
-	uint32_t modules_mask;
-	npmx_error_t err_code = npmx_charger_module_get(charger_instance, &modules_mask);
-	if (!check_error_code(shell, err_code)) {
-		shell_error(shell, "Error: unable to get charger module status.");
-		return 0;
-	}
-	if ((modules_mask & NPMX_CHARGER_MODULE_CHARGER_MASK) != 0) {
-		shell_error(shell, "Error: charger must be disabled to set ADC NTC value.");
-		return 0;
-	}
-
-	npmx_adc_t *adc_instance = npmx_adc_get(npmx_instance, 0);
-	npmx_adc_ntc_config_t ntc_config;
-	err_code = npmx_adc_ntc_config_get(adc_instance, &ntc_config);
-	if (!check_error_code(shell, err_code)) {
-		shell_error(shell, "Error: unable to read ADC NTC config.");
-		return 0;
-	}
-
-	bool recalculate_temps =
-		(config_type == ADC_NTC_CONFIG_PARAM_BETA &&
-		 ntc_config.type != NPMX_ADC_NTC_TYPE_HI_Z && ntc_config.beta != 0);
-	int16_t temp_cool, temp_cold, temp_warm, temp_hot;
-	if (recalculate_temps) {
-		err_code = npmx_charger_cold_temperature_get(charger_instance, &temp_cold);
-		if (!check_error_code(shell, err_code)) {
-			shell_error(shell, "Error: unable to read previous NTC cold treshold.");
-			return 0;
-		}
-		err_code = npmx_charger_cool_temperature_get(charger_instance, &temp_cool);
-		if (!check_error_code(shell, err_code)) {
-			shell_error(shell, "Error: unable to read previous NTC cool treshold.");
-			return 0;
-		}
-		err_code = npmx_charger_warm_temperature_get(charger_instance, &temp_warm);
-		if (!check_error_code(shell, err_code)) {
-			shell_error(shell, "Error: unable to read previous NTC warm treshold.");
-			return 0;
-		}
-		err_code = npmx_charger_hot_temperature_get(charger_instance, &temp_hot);
-		if (!check_error_code(shell, err_code)) {
-			shell_error(shell, "Error: unable to read previous NTC hot treshold.");
-			return 0;
-		}
-	}
-
-	switch (config_type) {
-	case ADC_NTC_CONFIG_PARAM_TYPE:
-		ntc_config.type = npmx_adc_ntc_type_convert(config_val);
-		if (ntc_config.type == NPMX_ADC_NTC_TYPE_INVALID) {
-			shell_error(shell, "Error: unable to convert resistance to NTC type.");
-			return 0;
-		}
-
-		if (ntc_config.type == NPMX_ADC_NTC_TYPE_HI_Z) {
-			err_code = npmx_charger_module_get(charger_instance, &modules_mask);
-			if (!check_error_code(shell, err_code)) {
-				shell_error(shell,
-					    "Error: unable to get NTC limits module status.");
-			}
-
-			if ((modules_mask & NPMX_CHARGER_MODULE_NTC_LIMITS_MASK) == 0) {
-				/* NTC limits module already disabled. */
-				break;
-			}
-
-			err_code = npmx_charger_module_disable_set(
-				charger_instance, NPMX_CHARGER_MODULE_NTC_LIMITS_MASK);
-			if (check_error_code(shell, err_code)) {
-				shell_info(
-					shell,
-					"Info: the NTC temperature limit control module has been disabled.");
-				shell_info(shell,
-					   "      To re-enable, change the NTC type to != 0.");
-			} else {
-				shell_error(
-					shell,
-					"Error: unable to disable the NTC temperature limit control module.");
-				return 0;
-			}
-		} else {
-			err_code = npmx_charger_module_get(charger_instance, &modules_mask);
-			if (!check_error_code(shell, err_code)) {
-				shell_error(shell,
-					    "Error: unable to get NTC limits module status.");
-			}
-
-			if ((modules_mask & NPMX_CHARGER_MODULE_NTC_LIMITS_MASK) > 0) {
-				/* NTC limits module already enabled. */
-				break;
-			}
-
-			err_code = npmx_charger_module_enable_set(
-				charger_instance, NPMX_CHARGER_MODULE_NTC_LIMITS_MASK);
-			if (check_error_code(shell, err_code)) {
-				shell_info(
-					shell,
-					"Info: the NTC temperature limit control module has been enabled.");
-			} else {
-				shell_error(
-					shell,
-					"Error: unable to enable the NTC temperature limit control module.");
-				return 0;
-			}
-		}
-		break;
-
-	case ADC_NTC_CONFIG_PARAM_BETA:
-		ntc_config.beta = config_val;
-		break;
-	}
-
-	err_code = npmx_adc_ntc_config_set(adc_instance, &ntc_config);
-	if (check_error_code(shell, err_code)) {
-		switch (config_type) {
-		case ADC_NTC_CONFIG_PARAM_TYPE:
-			shell_print(shell, "Success: %u Ohm.", config_val);
-			break;
-		case ADC_NTC_CONFIG_PARAM_BETA:
-			shell_print(shell, "Success: %u.", config_val);
-			break;
-		}
-	} else {
-		shell_error(shell, "Error: unable to set ADC NTC value.");
-		return 0;
-	}
-
-	if (recalculate_temps) {
-		err_code = npmx_charger_cold_temperature_set(charger_instance, temp_cold);
-		if (!check_error_code(shell, err_code)) {
-			shell_error(shell, "Error: unable to set new NTC cold treshold.");
-			return 0;
-		}
-		err_code = npmx_charger_cool_temperature_set(charger_instance, temp_cool);
-		if (!check_error_code(shell, err_code)) {
-			shell_error(shell, "Error: unable to set new NTC cool treshold.");
-			return 0;
-		}
-		err_code = npmx_charger_warm_temperature_set(charger_instance, temp_warm);
-		if (!check_error_code(shell, err_code)) {
-			shell_error(shell, "Error: unable to set new NTC warm treshold.");
-			return 0;
-		}
-		err_code = npmx_charger_hot_temperature_set(charger_instance, temp_hot);
-		if (!check_error_code(shell, err_code)) {
-			shell_error(shell, "Error: unable to set new NTC hot treshold.");
-			return 0;
-		}
-		shell_print(shell, "Info: NTC thresholds recalculated successfully.");
-	}
-
-	return 0;
-}
-
-static int cmd_adc_ntc_type_get(const struct shell *shell, size_t argc, char **argv)
-{
-	return adc_ntc_get(shell, argc, argv, ADC_NTC_CONFIG_PARAM_TYPE);
-}
-
-static int cmd_adc_ntc_type_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return adc_ntc_set(shell, argc, argv, ADC_NTC_CONFIG_PARAM_TYPE);
-}
-
-static int cmd_adc_ntc_beta_get(const struct shell *shell, size_t argc, char **argv)
-{
-	return adc_ntc_get(shell, argc, argv, ADC_NTC_CONFIG_PARAM_BETA);
-}
-
-static int cmd_adc_ntc_beta_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return adc_ntc_set(shell, argc, argv, ADC_NTC_CONFIG_PARAM_BETA);
-}
-
-static int cmd_adc_meas_take_vbat(const struct shell *shell, size_t argc, char **argv)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	npmx_adc_t *adc_instance = npmx_adc_get(npmx_instance, 0);
-
-	npmx_error_t err_code = npmx_adc_task_trigger(adc_instance, NPMX_ADC_TASK_SINGLE_SHOT_VBAT);
-
-	if (!check_error_code(shell, err_code)) {
-		shell_error(shell, "Error: unable to read getting measurement.");
-		return 0;
-	}
-
-	int32_t battery_voltage_millivolts;
-	bool meas_ready = false;
-
-	err_code = NPMX_ERROR_INVALID_PARAM;
-
-	while (!meas_ready) {
-		err_code = npmx_adc_meas_check(adc_instance, NPMX_ADC_MEAS_VBAT, &meas_ready);
-		if (!check_error_code(shell, err_code)) {
-			shell_error(shell, "Error: unable to read measurement's status.");
-			return 0;
-		}
-	}
-
-	err_code = npmx_adc_meas_get(adc_instance, NPMX_ADC_MEAS_VBAT, &battery_voltage_millivolts);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Value: %d mV.", battery_voltage_millivolts);
-	} else {
-		shell_error(shell, "Error: unable to read measurement's result.");
-	}
-
-	return 0;
-}
-
 static int pof_config_get(const struct shell *shell, pof_config_type_t config_type)
 {
 	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
@@ -4250,6 +4276,33 @@ static int cmd_reset(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
+/* Creating subcommands (level 3 command) array for command "adc meas". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_adc_meas,
+			       SHELL_CMD(vbat, NULL, "Get battery voltage", cmd_adc_meas_vbat_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "adc ntc beta". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_adc_ntc_beta,
+			       SHELL_CMD(set, NULL, "Set ADC NTC beta value", cmd_adc_ntc_beta_set),
+			       SHELL_CMD(get, NULL, "Get ADC NTC beta value", cmd_adc_ntc_beta_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "adc ntc type". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_adc_ntc_type,
+			       SHELL_CMD(set, NULL, "Set ADC NTC type", cmd_adc_ntc_type_set),
+			       SHELL_CMD(get, NULL, "Get ADC NTC type", cmd_adc_ntc_type_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 3 command) array for command "adc ntc_type". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_adc_ntc,
+			       SHELL_CMD(beta, &sub_adc_ntc_beta, "ADC NTC beta", NULL),
+			       SHELL_CMD(type, &sub_adc_ntc_type, "ADC NTC type", NULL),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 2 command) array for command "adc". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_adc, SHELL_CMD(meas, &sub_adc_meas, "ADC measurement", NULL),
+			       SHELL_CMD(ntc, &sub_adc_ntc, "ADC NTC", NULL), SHELL_SUBCMD_SET_END);
+
 /* Creating subcommands (level 4 command) array for command "charger termination_voltage normal". */
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_termination_voltage_normal,
 			       SHELL_CMD(get, NULL, "Get charger normal termination voltage",
@@ -4744,40 +4797,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(debounce, &sub_gpio_debounce, "Debounce configuration", NULL),
 	SHELL_SUBCMD_SET_END);
 
-/* Creating subcommands (level 4 command) array for command "adc ntc type". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_adc_ntc_type,
-			       SHELL_CMD(get, NULL, "Get ADC NTC type", cmd_adc_ntc_type_get),
-			       SHELL_CMD(set, NULL, "Set ADC NTC type", cmd_adc_ntc_type_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 4 command) array for command "adc ntc beta". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_adc_ntc_beta,
-			       SHELL_CMD(get, NULL, "Get ADC NTC beta value", cmd_adc_ntc_beta_get),
-			       SHELL_CMD(set, NULL, "Set ADC NTC beta value", cmd_adc_ntc_beta_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 3 command) array for command "adc ntc". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_adc_ntc,
-			       SHELL_CMD(type, &sub_adc_ntc_type, "ADC NTC type", NULL),
-			       SHELL_CMD(beta, &sub_adc_ntc_beta, "ADC NTC beta", NULL),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 4 command) array for command "adc take meas". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_adc_meas_take,
-			       SHELL_CMD(vbat, NULL, "Read battery voltage",
-					 cmd_adc_meas_take_vbat),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 3 command) array for command "adc meas". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_adc_meas,
-			       SHELL_CMD(take, &sub_adc_meas_take, "Take ADC measurement", NULL),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 2 command) array for command "adc". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_adc, SHELL_CMD(ntc, &sub_adc_ntc, "ADC NTC value", NULL),
-			       SHELL_CMD(meas, &sub_adc_meas, "ADC measurement", NULL),
-			       SHELL_SUBCMD_SET_END);
-
 /* Creating subcommands (level 3 command) array for command "pof enable". */
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_pof_enable, SHELL_CMD(get, NULL, "Check if POF feature is enabled", cmd_pof_enable_get),
@@ -4935,10 +4954,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_ship, SHELL_CMD(config, &sub_ship_config, "Sh
 
 /* Creating subcommands (level 1 command) array for command "npmx". */
 SHELL_STATIC_SUBCMD_SET_CREATE(
-	sub_npmx, SHELL_CMD(charger, &sub_charger, "Charger", NULL),
-	SHELL_CMD(buck, &sub_buck, "Buck", NULL), SHELL_CMD(ldsw, &sub_ldsw, "LDSW", NULL),
-	SHELL_CMD(leds, &sub_leds, "LEDs", NULL), SHELL_CMD(gpio, &sub_gpio, "GPIOs", NULL),
-	SHELL_CMD(adc, &sub_adc, "ADC", NULL), SHELL_CMD(pof, &sub_pof, "POF", NULL),
+	sub_npmx, SHELL_CMD(adc, &sub_adc, "ADC", NULL),
+	SHELL_CMD(charger, &sub_charger, "Charger", NULL), SHELL_CMD(buck, &sub_buck, "Buck", NULL),
+	SHELL_CMD(ldsw, &sub_ldsw, "LDSW", NULL), SHELL_CMD(leds, &sub_leds, "LEDs", NULL),
+	SHELL_CMD(gpio, &sub_gpio, "GPIOs", NULL), SHELL_CMD(pof, &sub_pof, "POF", NULL),
 	SHELL_CMD(timer, &sub_timer, "Timer", NULL),
 	SHELL_CMD(errlog, &sub_errlog, "Reset errors logs", NULL),
 	SHELL_CMD(vbusin, &sub_vbusin, "VBUSIN", NULL), SHELL_CMD(ship, &sub_ship, "SHIP", NULL),

--- a/drivers/npmx/npmx_shell.c
+++ b/drivers/npmx/npmx_shell.c
@@ -4,14 +4,17 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <assert.h>
-#include <stdlib.h>
-#include <ctype.h>
 #include <npmx.h>
 #include <npmx_driver.h>
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
+#include <assert.h>
+#include <ctype.h>
 #include <math.h>
+#include <stdlib.h>
+
+/** @brief Max supported number of shell arguments. */
+#define SHELL_ARG_MAX_COUNT 3U
 
 /** @brief GPIO configuration type. */
 typedef enum {
@@ -61,6 +64,44 @@ typedef enum {
 	ADC_NTC_CONFIG_PARAM_BETA /* Battery NTC beta value. */
 } adc_ntc_config_param_t;
 
+/** @brief Supported shell argument types. */
+typedef enum {
+	SHELL_ARG_TYPE_INT32_VALUE, /* Shell int32_t type used for values. */
+	SHELL_ARG_TYPE_UINT32_VALUE, /* Shell uint32_t type used for values. */
+	SHELL_ARG_TYPE_BOOL_VALUE, /* Shell bool type used for values. */
+	SHELL_ARG_TYPE_UINT32_INDEX, /* Shell uint32_t type used for peripherals index. */
+} shell_arg_type_t;
+
+/** @brief Shell argument result value. */
+typedef union {
+	int32_t ivalue; /* int32_t result. */
+	uint32_t uvalue; /* uint32_t result. */
+	bool bvalue; /* bool result. */
+} shell_arg_result_t;
+
+/** @brief Shell argument structure. */
+typedef struct {
+	const shell_arg_type_t type; /* Shell argument type. */
+	const char *name; /* Shell argument name. */
+	shell_arg_result_t result; /* Shell argument result. */
+} shell_arg_t;
+
+/** @brief Shell arguments infomation structure. */
+typedef struct {
+	const int expected_args; /* Expected arguments count. */
+	shell_arg_t arg[SHELL_ARG_MAX_COUNT]; /* Shell arguments. */
+} args_info_t;
+
+/** @brief Supported unit types. */
+typedef enum {
+	UNIT_TYPE_MILLIAMPERE, /* Unit type mA. */
+	UNIT_TYPE_MILLIVOLT, /* Unit type mV. */
+	UNIT_TYPE_CELSIUS, /* Unit type *C. */
+	UNIT_TYPE_OHM, /* Unit type ohms. */
+	UNIT_TYPE_PCT, /* Unit type %. */
+	UNIT_TYPE_NONE, /* No unit type. */
+} unit_type_t;
+
 static const struct device *pmic_dev = DEVICE_DT_GET(DT_NODELABEL(npm_0));
 
 static bool check_error_code(const struct shell *shell, npmx_error_t err_code)
@@ -82,6 +123,176 @@ static bool check_error_code(const struct shell *shell, npmx_error_t err_code)
 	}
 
 	return false;
+}
+
+static const char *unit_str_get(unit_type_t unit_type)
+{
+	switch (unit_type) {
+	case UNIT_TYPE_MILLIAMPERE:
+		return " mA";
+	case UNIT_TYPE_MILLIVOLT:
+		return " mV";
+	case UNIT_TYPE_CELSIUS:
+		return "*C";
+	case UNIT_TYPE_OHM:
+		return " ohms";
+	case UNIT_TYPE_PCT:
+		return "%";
+	default:
+		return "";
+	}
+}
+
+static void print_value(const struct shell *shell, int value, unit_type_t unit_type)
+{
+	shell_print(shell, "Value: %d%s.", value, unit_str_get(unit_type));
+}
+
+static void print_success(const struct shell *shell, int value, unit_type_t unit_type)
+{
+	shell_print(shell, "Success: %d%s.", value, unit_str_get(unit_type));
+}
+
+static void print_hint_error(const struct shell *shell, int32_t index, const char *str)
+{
+	shell_error(shell, "%d-%s", index, str);
+}
+
+static void print_set_error(const struct shell *shell, const char *str)
+{
+	shell_error(shell, "Error: unable to set %s.", str);
+}
+
+static void print_get_error(const struct shell *shell, const char *str)
+{
+	shell_error(shell, "Error: unable to get %s.", str);
+}
+
+static void print_convert_error(const struct shell *shell, const char *src, const char *dst)
+{
+	shell_error(shell, "Error: unable to convert %s to %s.", src, dst);
+}
+
+static const char *message_ending_get(shell_arg_type_t arg_type)
+{
+	switch (arg_type) {
+	case SHELL_ARG_TYPE_INT32_VALUE:
+	case SHELL_ARG_TYPE_UINT32_VALUE:
+	case SHELL_ARG_TYPE_BOOL_VALUE:
+		return "value";
+	case SHELL_ARG_TYPE_UINT32_INDEX:
+		return "instance index";
+	}
+	return "";
+}
+
+static bool arguments_check(const struct shell *shell, size_t argc, char **argv,
+			    args_info_t *args_info)
+{
+	__ASSERT_NO_MSG(args_info);
+	__ASSERT_NO_MSG(args_info->expected_args <= SHELL_ARG_MAX_COUNT);
+
+	/* argc and argv have also an information about command name, here it should be skipped. */
+	argc--;
+	/* Only arguments passed to commands are used. Command name is skipped. */
+	argv++;
+
+	/* Check if all argument are passed. */
+	if (argc < args_info->expected_args) {
+		shell_arg_t *missing_args = &args_info->arg[argc];
+		int missing_count = args_info->expected_args - argc;
+		switch (missing_count) {
+		case 1:
+			shell_error(shell, "Error: missing %s %s.", missing_args[0].name,
+				    message_ending_get(missing_args[0].type));
+			break;
+		case 2:
+			shell_error(shell, "Error: missing %s %s and %s %s.", missing_args[0].name,
+				    message_ending_get(missing_args[0].type), missing_args[1].name,
+				    message_ending_get(missing_args[1].type));
+			break;
+		case 3:
+			shell_error(shell, "Error: missing %s %s, %s %s and %s %s.",
+				    missing_args[0].name, message_ending_get(missing_args[0].type),
+				    missing_args[1].name, message_ending_get(missing_args[1].type),
+				    missing_args[2].name, message_ending_get(missing_args[2].type));
+			break;
+		}
+		return false;
+	}
+
+	for (int i = 0; i < args_info->expected_args; i++) {
+		shell_arg_t *arg_info = &args_info->arg[i];
+		__ASSERT_NO_MSG(arg_info);
+
+		int err = 0;
+		switch (arg_info->type) {
+		case SHELL_ARG_TYPE_INT32_VALUE:
+			arg_info->result.ivalue = shell_strtol(argv[i], 0, &err);
+			if (err != 0) {
+				shell_error(shell, "Error: %s has to be an integer.",
+					    arg_info->name);
+				return false;
+			}
+			break;
+		case SHELL_ARG_TYPE_UINT32_VALUE:
+		case SHELL_ARG_TYPE_UINT32_INDEX:
+			arg_info->result.uvalue = shell_strtoul(argv[i], 0, &err);
+			if (err != 0) {
+				shell_error(shell, "Error: %s has to be a non-negative integer.",
+					    arg_info->name);
+				return false;
+			}
+			break;
+		case SHELL_ARG_TYPE_BOOL_VALUE:
+			const char *str = argv[i];
+			/* shell_strtobool can't be used due to accepting any big value as true. */
+			if ((strcmp(str, "on") == 0) || (strcmp(str, "enable") == 0) ||
+			    (strcmp(str, "true") == 0)) {
+				arg_info->result.bvalue = true;
+				break;
+			}
+			if ((strcmp(str, "off") == 0) || (strcmp(str, "disable") == 0) ||
+			    (strcmp(str, "false") == 0)) {
+				arg_info->result.bvalue = false;
+				break;
+			}
+
+			uint32_t bool_value = shell_strtoul(str, 0, &err);
+			if ((err != 0) || (bool_value > 1)) {
+				shell_error(shell, "Error: invalid %s value.", arg_info->name);
+				return false;
+			}
+
+			arg_info->result.bvalue = bool_value == 1;
+			break;
+		}
+	}
+
+	return true;
+}
+
+static npmx_instance_t *npmx_instance_get(const struct shell *shell)
+{
+	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
+	if (npmx_instance == NULL) {
+		shell_error(shell, "Error: shell is not initialized.");
+		return NULL;
+	}
+
+	return npmx_instance;
+}
+
+static bool check_instance_index(const struct shell *shell, const char *instance_name,
+				 uint32_t index, uint32_t max_index)
+{
+	if (index >= max_index) {
+		shell_error(shell, "Error: %s instance index is too high: no such instance.",
+			    instance_name);
+		return false;
+	}
+
+	return true;
 }
 
 static bool check_pin_configuration_correctness(const struct shell *shell, int8_t gpio_idx)

--- a/drivers/npmx/npmx_shell.c
+++ b/drivers/npmx/npmx_shell.c
@@ -3036,6 +3036,26 @@ static int cmd_pof_threshold_get(const struct shell *shell, size_t argc, char **
 	return pof_config_get(shell, POF_CONFIG_PARAM_THRESHOLD);
 }
 
+static int cmd_reset(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
+	if (npmx_instance == NULL) {
+		return 0;
+	}
+
+	npmx_error_t err_code = npmx_core_task_trigger(npmx_instance, NPMX_CORE_TASK_RESET);
+	if (!check_error_code(shell, err_code)) {
+		shell_error(shell, "Error: unable to reset device.");
+		return 0;
+	}
+
+	shell_print(shell, "Success: resetting.");
+	return 0;
+}
+
 static int ship_config_set(const struct shell *shell, size_t argc, char **argv,
 			   ship_config_param_t config_type)
 {
@@ -3559,29 +3579,6 @@ static int cmd_vbusin_status_connected_get(const struct shell *shell, size_t arg
 	}
 
 	print_value(shell, !!(status_mask & NPMX_VBUSIN_STATUS_CONNECTED_MASK), UNIT_TYPE_NONE);
-	return 0;
-}
-
-static int cmd_reset(const struct shell *shell, size_t argc, char **argv)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	npmx_error_t err_code = npmx_core_task_trigger(npmx_instance, NPMX_CORE_TASK_RESET);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Success: restarting.");
-	} else {
-		shell_error(shell, "Error: unable to restart device.");
-	}
-
 	return 0;
 }
 
@@ -4259,9 +4256,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(errlog, &sub_errlog, "Reset errors logs", NULL),
 	SHELL_CMD(gpio, &sub_gpio, "GPIO", NULL), SHELL_CMD(ldsw, &sub_ldsw, "LDSW", NULL),
 	SHELL_CMD(led, &sub_led, "LED", NULL), SHELL_CMD(pof, &sub_pof, "POF", NULL),
-	SHELL_CMD(ship, &sub_ship, "SHIP", NULL), SHELL_CMD(timer, &sub_timer, "Timer", NULL),
-	SHELL_CMD(vbusin, &sub_vbusin, "VBUSIN", NULL),
-	SHELL_CMD(reset, NULL, "Restart device", cmd_reset), SHELL_SUBCMD_SET_END);
+	SHELL_CMD(reset, NULL, "Reset device", cmd_reset), SHELL_CMD(ship, &sub_ship, "SHIP", NULL),
+	SHELL_CMD(timer, &sub_timer, "Timer", NULL), SHELL_CMD(vbusin, &sub_vbusin, "VBUSIN", NULL),
+	SHELL_SUBCMD_SET_END);
 
 /* Creating root (level 0) command "npmx" without a handler. */
 SHELL_CMD_REGISTER(npmx, &sub_npmx, "npmx", NULL);

--- a/drivers/npmx/npmx_shell.c
+++ b/drivers/npmx/npmx_shell.c
@@ -45,24 +45,24 @@ typedef enum {
 	POF_CONFIG_PARAM_THRESHOLD, /* POF threshold value. */
 } pof_config_param_t;
 
+/** @brief SHIP config parameter. */
+typedef enum {
+	SHIP_CONFIG_PARAM_INV_POLARITY, /* Device is to invert the SHPHLD button active status. */
+	SHIP_CONFIG_PARAM_TIME, /* Time required to exit from the ship or the hibernate mode. */
+} ship_config_param_t;
+
+/** @brief SHIP reset config parameter. */
+typedef enum {
+	SHIP_RESET_CONFIG_PARAM_LONG_PRESS, /* Use long press (10 s) button. */
+	SHIP_RESET_CONFIG_PARAM_TWO_BUTTONS /* Use two buttons (SHPHLD and GPIO0). */
+} ship_reset_config_param_t;
+
 /** @brief Timer configuration type. */
 typedef enum {
 	TIMER_CONFIG_TYPE_MODE, /* Configure timer mode. */
 	TIMER_CONFIG_TYPE_PRESCALER, /* Configure timer prescaler mode. */
 	TIMER_CONFIG_TYPE_COMPARE, /* Configure timer compare value. */
 } timer_config_type_t;
-
-/** @brief SHIP configuration type. */
-typedef enum {
-	SHIP_CONFIG_TYPE_TIME, /* Time required to exit from the ship or the hibernate mode. */
-	SHIP_CONFIG_TYPE_INV_POLARITY /* Device is to invert the SHPHLD button active status. */
-} ship_config_type_t;
-
-/** @brief SHIP reset configuration type. */
-typedef enum {
-	SHIP_RESET_CONFIG_TYPE_LONG_PRESS, /* Use long press (10 s) button. */
-	SHIP_RESET_CONFIG_TYPE_TWO_BUTTONS /* Use two buttons (SHPHLD and GPIO0). */
-} ship_reset_config_type_t;
 
 /** @brief Supported shell argument types. */
 typedef enum {
@@ -364,6 +364,13 @@ static npmx_pof_t *pof_instance_get(const struct shell *shell)
 	npmx_instance_t *npmx_instance = npmx_instance_get(shell);
 
 	return npmx_instance ? npmx_pof_get(npmx_instance, 0) : NULL;
+}
+
+static npmx_ship_t *ship_instance_get(const struct shell *shell)
+{
+	npmx_instance_t *npmx_instance = npmx_instance_get(shell);
+
+	return npmx_instance ? npmx_ship_get(npmx_instance, 0) : NULL;
 }
 
 static bool check_pin_configuration_correctness(const struct shell *shell, int8_t gpio_idx)
@@ -3015,6 +3022,258 @@ static int cmd_pof_threshold_get(const struct shell *shell, size_t argc, char **
 	return pof_config_get(shell, POF_CONFIG_PARAM_THRESHOLD);
 }
 
+static int ship_config_set(const struct shell *shell, size_t argc, char **argv,
+			   ship_config_param_t config_type)
+{
+	shell_arg_type_t arg_type;
+	const char *config_name;
+	switch (config_type) {
+	case SHIP_CONFIG_PARAM_TIME:
+		arg_type = SHELL_ARG_TYPE_UINT32_VALUE;
+		config_name = "time";
+		break;
+	case SHIP_CONFIG_PARAM_INV_POLARITY:
+		arg_type = SHELL_ARG_TYPE_BOOL_VALUE;
+		config_name = "polarity";
+		break;
+	}
+
+	args_info_t args_info = { .expected_args = 1,
+				  .arg = {
+					  [0] = { arg_type, config_name },
+				  } };
+	if (!arguments_check(shell, argc, argv, &args_info)) {
+		return 0;
+	}
+
+	npmx_ship_t *ship_instance = ship_instance_get(shell);
+	if (ship_instance == NULL) {
+		return 0;
+	}
+
+	npmx_ship_config_t config;
+	npmx_error_t err_code = npmx_ship_config_get(ship_instance, &config);
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "ship config");
+		return 0;
+	}
+
+	shell_arg_result_t config_value = args_info.arg[0].result;
+	switch (config_type) {
+	case SHIP_CONFIG_PARAM_TIME:
+		config.time = npmx_ship_time_convert(config_value.uvalue);
+		if (config.time == NPMX_SHIP_TIME_INVALID) {
+			print_convert_error(shell, "milliseconds", "ship time");
+			return 0;
+		}
+		break;
+	case SHIP_CONFIG_PARAM_INV_POLARITY:
+		config.inverted_polarity = config_value.bvalue;
+		break;
+	}
+
+	err_code = npmx_ship_config_set(ship_instance, &config);
+	if (!check_error_code(shell, err_code)) {
+		print_set_error(shell, "ship config");
+		return 0;
+	}
+
+	print_success(shell, config_value.uvalue, UNIT_TYPE_NONE);
+	return 0;
+}
+
+static int ship_config_get(const struct shell *shell, ship_config_param_t config_type)
+{
+	npmx_ship_t *ship_instance = ship_instance_get(shell);
+	if (ship_instance == NULL) {
+		return 0;
+	}
+
+	npmx_ship_config_t config;
+	npmx_error_t err_code = npmx_ship_config_get(ship_instance, &config);
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "ship config");
+		return 0;
+	}
+
+	switch (config_type) {
+	case SHIP_CONFIG_PARAM_TIME:
+		uint32_t time;
+		if (!npmx_ship_time_convert_to_ms(config.time, &time)) {
+			print_convert_error(shell, "ship time", "milliseconds");
+			return 0;
+		}
+		print_value(shell, time, UNIT_TYPE_NONE);
+		break;
+	case SHIP_CONFIG_PARAM_INV_POLARITY:
+		print_value(shell, config.inverted_polarity, UNIT_TYPE_NONE);
+		break;
+	}
+	return 0;
+}
+
+static int cmd_ship_config_inv_polarity_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return ship_config_set(shell, argc, argv, SHIP_CONFIG_PARAM_INV_POLARITY);
+}
+
+static int cmd_ship_config_inv_polarity_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return ship_config_get(shell, SHIP_CONFIG_PARAM_INV_POLARITY);
+}
+
+static int cmd_ship_config_time_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return ship_config_set(shell, argc, argv, SHIP_CONFIG_PARAM_TIME);
+}
+
+static int cmd_ship_config_time_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return ship_config_get(shell, SHIP_CONFIG_PARAM_TIME);
+}
+
+static int ship_mode_set(const struct shell *shell, npmx_ship_task_t ship_task)
+{
+	npmx_ship_t *ship_instance = ship_instance_get(shell);
+	if (ship_instance == NULL) {
+		return 0;
+	}
+
+	npmx_error_t err_code = npmx_ship_task_trigger(ship_instance, ship_task);
+	if (!check_error_code(shell, err_code)) {
+		print_set_error(shell, "ship mode");
+		return 0;
+	}
+
+	print_success(shell, true, UNIT_TYPE_NONE);
+	return 0;
+}
+
+static int cmd_ship_mode_hibernate_set(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return ship_mode_set(shell, NPMX_SHIP_TASK_HIBERNATE);
+}
+
+static int cmd_ship_mode_ship_set(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return ship_mode_set(shell, NPMX_SHIP_TASK_SHIPMODE);
+}
+
+static int ship_reset_config_set(const struct shell *shell, size_t argc, char **argv,
+				 ship_reset_config_param_t config_type)
+{
+	const char *config_name;
+	switch (config_type) {
+	case SHIP_RESET_CONFIG_PARAM_LONG_PRESS:
+		config_name = "long press";
+		break;
+	case SHIP_RESET_CONFIG_PARAM_TWO_BUTTONS:
+		config_name = "two buttons";
+		break;
+	}
+
+	args_info_t args_info = { .expected_args = 1,
+				  .arg = {
+					  [0] = { SHELL_ARG_TYPE_BOOL_VALUE, config_name },
+				  } };
+	if (!arguments_check(shell, argc, argv, &args_info)) {
+		return 0;
+	}
+
+	npmx_ship_t *ship_instance = ship_instance_get(shell);
+	if (ship_instance == NULL) {
+		return 0;
+	}
+
+	npmx_ship_reset_config_t reset_config;
+	npmx_error_t err_code = npmx_ship_reset_config_get(ship_instance, &reset_config);
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "reset config");
+		return 0;
+	}
+
+	bool config_value = args_info.arg[0].result.bvalue;
+	switch (config_type) {
+	case SHIP_RESET_CONFIG_PARAM_LONG_PRESS:
+		reset_config.long_press = config_value;
+		break;
+	case SHIP_RESET_CONFIG_PARAM_TWO_BUTTONS:
+		reset_config.two_buttons = config_value;
+		break;
+	}
+
+	err_code = npmx_ship_reset_config_set(ship_instance, &reset_config);
+	if (!check_error_code(shell, err_code)) {
+		print_set_error(shell, "reset config");
+		return 0;
+	}
+
+	print_success(shell, config_value, UNIT_TYPE_NONE);
+	return 0;
+}
+
+static int ship_reset_config_get(const struct shell *shell, ship_reset_config_param_t config_type)
+{
+	npmx_ship_t *ship_instance = ship_instance_get(shell);
+	if (ship_instance == NULL) {
+		return 0;
+	}
+
+	npmx_ship_reset_config_t reset_config;
+	npmx_error_t err_code = npmx_ship_reset_config_get(ship_instance, &reset_config);
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "reset config");
+	}
+
+	switch (config_type) {
+	case SHIP_RESET_CONFIG_PARAM_LONG_PRESS:
+		print_value(shell, reset_config.long_press, UNIT_TYPE_NONE);
+		break;
+	case SHIP_RESET_CONFIG_PARAM_TWO_BUTTONS:
+		print_value(shell, reset_config.two_buttons, UNIT_TYPE_NONE);
+		break;
+	}
+	return 0;
+}
+
+static int cmd_ship_reset_long_press_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return ship_reset_config_set(shell, argc, argv, SHIP_RESET_CONFIG_PARAM_LONG_PRESS);
+}
+
+static int cmd_ship_reset_long_press_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return ship_reset_config_get(shell, SHIP_RESET_CONFIG_PARAM_LONG_PRESS);
+}
+
+static int cmd_ship_reset_two_buttons_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return ship_reset_config_set(shell, argc, argv, SHIP_RESET_CONFIG_PARAM_TWO_BUTTONS);
+}
+
+static int cmd_ship_reset_two_buttons_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return ship_reset_config_get(shell, SHIP_RESET_CONFIG_PARAM_TWO_BUTTONS);
+}
+
 static npmx_timer_mode_t timer_mode_int_convert_to_enum(uint32_t timer_mode)
 {
 	switch (timer_mode) {
@@ -3316,281 +3575,6 @@ static int cmd_vbusin_current_limit_set(const struct shell *shell, size_t argc, 
 	}
 
 	return 0;
-}
-
-static int ship_config_get(const struct shell *shell, ship_config_type_t config_type)
-{
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	npmx_ship_config_t config;
-	npmx_ship_t *ship_instance = npmx_ship_get(npmx_instance, 0);
-	npmx_error_t err_code = npmx_ship_config_get(ship_instance, &config);
-
-	if (check_error_code(shell, err_code)) {
-		uint32_t config_val = 0;
-
-		switch (config_type) {
-		case SHIP_CONFIG_TYPE_TIME:
-			if (!npmx_ship_time_convert_to_ms(config.time, &config_val)) {
-				shell_error(shell, "Error: unable to convert.");
-				return 0;
-			}
-			break;
-
-		case SHIP_CONFIG_TYPE_INV_POLARITY:
-			config_val = (uint32_t)config.inverted_polarity;
-			break;
-		}
-
-		shell_print(shell, "Value: %u.", config_val);
-	} else {
-		shell_error(shell, "Error: unable to read config.");
-	}
-
-	return 0;
-}
-
-static int ship_config_set(const struct shell *shell, size_t argc, char **argv,
-			   ship_config_type_t config_type)
-{
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	if (argc < 2) {
-		shell_error(shell, "Error: missing config value.");
-		return 0;
-	}
-
-	int err = 0;
-	uint32_t config_val = shell_strtoul(argv[1], 0, &err);
-
-	if (err != 0) {
-		shell_error(shell, "Error: config value must be an integer.");
-		return 0;
-	}
-
-	npmx_ship_config_t config;
-	npmx_ship_t *ship_instance = npmx_ship_get(npmx_instance, 0);
-
-	npmx_error_t err_code = npmx_ship_config_get(ship_instance, &config);
-
-	if (!check_error_code(shell, err_code)) {
-		shell_error(shell, "Error: unable to read config.");
-		return 0;
-	}
-
-	switch (config_type) {
-	case SHIP_CONFIG_TYPE_TIME:
-		npmx_ship_time_t time = npmx_ship_time_convert(config_val);
-		if (time == NPMX_SHIP_TIME_INVALID) {
-			shell_error(shell, "Error: wrong time value.");
-			return 0;
-		}
-		config.time = time;
-		break;
-
-	case SHIP_CONFIG_TYPE_INV_POLARITY:
-		config.inverted_polarity = !!config_val;
-		break;
-	}
-
-	err_code = npmx_ship_config_set(ship_instance, &config);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Success: %u.", config_val);
-	} else {
-		shell_error(shell, "Error: unable to set config.");
-	}
-
-	return 0;
-}
-
-static int cmd_ship_config_time_get(const struct shell *shell, size_t argc, char **argv)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	return ship_config_get(shell, SHIP_CONFIG_TYPE_TIME);
-}
-
-static int cmd_ship_config_time_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return ship_config_set(shell, argc, argv, SHIP_CONFIG_TYPE_TIME);
-}
-
-static int cmd_ship_config_inv_polarity_get(const struct shell *shell, size_t argc, char **argv)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	return ship_config_get(shell, SHIP_CONFIG_TYPE_INV_POLARITY);
-}
-
-static int cmd_ship_config_inv_polarity_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return ship_config_set(shell, argc, argv, SHIP_CONFIG_TYPE_INV_POLARITY);
-}
-
-static int ship_reset_config_get(const struct shell *shell, ship_reset_config_type_t config_type)
-{
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	npmx_ship_reset_config_t reset_config;
-	npmx_ship_t *ship_instance = npmx_ship_get(npmx_instance, 0);
-	npmx_error_t err_code = npmx_ship_reset_config_get(ship_instance, &reset_config);
-
-	if (check_error_code(shell, err_code)) {
-		bool config_val = false;
-
-		switch (config_type) {
-		case SHIP_RESET_CONFIG_TYPE_LONG_PRESS:
-			config_val = reset_config.long_press;
-			break;
-
-		case SHIP_RESET_CONFIG_TYPE_TWO_BUTTONS:
-			config_val = reset_config.two_buttons;
-			break;
-		}
-
-		shell_print(shell, "Value: %u.", config_val);
-	} else {
-		shell_error(shell, "Error: unable to read reset config.");
-	}
-
-	return 0;
-}
-
-static int ship_reset_config_set(const struct shell *shell, size_t argc, char **argv,
-				 ship_reset_config_type_t config_type)
-{
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	if (argc < 2) {
-		shell_error(shell, "Error: missing config value.");
-		return 0;
-	}
-
-	int err = 0;
-	uint32_t config_val = shell_strtoul(argv[1], 0, &err);
-
-	if (err != 0) {
-		shell_error(shell, "Error: config value must be an integer.");
-		return 0;
-	}
-
-	npmx_ship_reset_config_t reset_config;
-	npmx_ship_t *ship_instance = npmx_ship_get(npmx_instance, 0);
-
-	npmx_error_t err_code = npmx_ship_reset_config_get(ship_instance, &reset_config);
-
-	if (!check_error_code(shell, err_code)) {
-		shell_error(shell, "Error: unable to read reset config.");
-		return 0;
-	}
-
-	bool val = !!config_val;
-
-	switch (config_type) {
-	case SHIP_RESET_CONFIG_TYPE_LONG_PRESS:
-		reset_config.long_press = val;
-		break;
-	case SHIP_RESET_CONFIG_TYPE_TWO_BUTTONS:
-		reset_config.two_buttons = val;
-		break;
-	}
-
-	err_code = npmx_ship_reset_config_set(ship_instance, &reset_config);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Success: %d.", val);
-	} else {
-		shell_error(shell, "Error: unable to set reset config.");
-	}
-
-	return 0;
-}
-
-static int cmd_ship_reset_long_press_get(const struct shell *shell, size_t argc, char **argv)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	return ship_reset_config_get(shell, SHIP_RESET_CONFIG_TYPE_LONG_PRESS);
-}
-
-static int cmd_ship_reset_long_press_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return ship_reset_config_set(shell, argc, argv, SHIP_RESET_CONFIG_TYPE_LONG_PRESS);
-}
-
-static int cmd_ship_reset_two_buttons_get(const struct shell *shell, size_t argc, char **argv)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	return ship_reset_config_get(shell, SHIP_RESET_CONFIG_TYPE_TWO_BUTTONS);
-}
-
-static int cmd_ship_reset_two_buttons_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return ship_reset_config_set(shell, argc, argv, SHIP_RESET_CONFIG_TYPE_TWO_BUTTONS);
-}
-
-static int ship_mode_set(const struct shell *shell, npmx_ship_task_t ship_task)
-{
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	npmx_ship_t *ship_instance = npmx_ship_get(npmx_instance, 0);
-
-	npmx_error_t err_code = npmx_ship_task_trigger(ship_instance, ship_task);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Success: 1.");
-	} else {
-		shell_error(shell, "Error: unable to set mode.");
-	}
-
-	return 0;
-}
-
-static int cmd_ship_mode_ship_set(const struct shell *shell, size_t argc, char **argv)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	return ship_mode_set(shell, NPMX_SHIP_TASK_SHIPMODE);
-}
-
-static int cmd_ship_mode_hibernate_set(const struct shell *shell, size_t argc, char **argv)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	return ship_mode_set(shell, NPMX_SHIP_TASK_HIBERNATE);
 }
 
 static int cmd_reset(const struct shell *shell, size_t argc, char **argv)
@@ -4161,6 +4145,62 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(threshold, &sub_pof_threshold, "Vsys comparator threshold select", NULL),
 	SHELL_SUBCMD_SET_END);
 
+/* Creating subcommands (level 4 command) array for command "ship config time". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_ship_config_time,
+			       SHELL_CMD(set, NULL, "Set ship exit time", cmd_ship_config_time_set),
+			       SHELL_CMD(get, NULL, "Get ship exit time", cmd_ship_config_time_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "ship config inv_polarity". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_ship_config_inv_polarity,
+			       SHELL_CMD(set, NULL, "Set inverted polarity status",
+					 cmd_ship_config_inv_polarity_set),
+			       SHELL_CMD(get, NULL, "Get inverted polarity status",
+					 cmd_ship_config_inv_polarity_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 3 command) array for command "ship config". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_ship_config,
+			       SHELL_CMD(inv_polarity, &sub_ship_config_inv_polarity,
+					 "Button invert polarity", NULL),
+			       SHELL_CMD(time, &sub_ship_config_time, "Time", NULL),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 3 command) array for command "ship mode". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_ship_mode,
+			       SHELL_CMD(hibernate, NULL, "Enter hibernate mode",
+					 cmd_ship_mode_hibernate_set),
+			       SHELL_CMD(ship, NULL, "Enter ship mode", cmd_ship_mode_ship_set),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "ship reset long_press". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_ship_reset_long_press,
+			       SHELL_CMD(set, NULL, "Set long press status",
+					 cmd_ship_reset_long_press_set),
+			       SHELL_CMD(get, NULL, "Get long press status",
+					 cmd_ship_reset_long_press_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "ship reset two_buttons". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_ship_reset_two_buttons,
+			       SHELL_CMD(set, NULL, "Set two buttons status",
+					 cmd_ship_reset_two_buttons_set),
+			       SHELL_CMD(get, NULL, "Get two buttons status",
+					 cmd_ship_reset_two_buttons_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 3 command) array for command "ship reset". */
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_ship_reset, SHELL_CMD(long_press, &sub_ship_reset_long_press, "Long press", NULL),
+	SHELL_CMD(two_buttons, &sub_ship_reset_two_buttons, "Two buttons", NULL),
+	SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 2 command) array for command "ship". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_ship, SHELL_CMD(config, &sub_ship_config, "Ship config", NULL),
+			       SHELL_CMD(mode, &sub_ship_mode, "Set ship mode", NULL),
+			       SHELL_CMD(reset, &sub_ship_reset, "Reset button config", NULL),
+			       SHELL_SUBCMD_SET_END);
+
 /* Creating subcommands (level 4 command) array for command "timer config mode". */
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_timer_config_mode,
 			       SHELL_CMD(get, NULL, "Get timer mode value",
@@ -4229,62 +4269,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_vbusin, SHELL_CMD(status, &sub_vbusin_status,
 					 NULL),
 			       SHELL_SUBCMD_SET_END);
 
-/* Creating subcommands (level 4 command) array for command "ship config time". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ship_config_time,
-			       SHELL_CMD(get, NULL, "Get ship exit time", cmd_ship_config_time_get),
-			       SHELL_CMD(set, NULL, "Set ship exit time", cmd_ship_config_time_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 4 command) array for command "ship config inv_polarity". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ship_config_inv_polarity,
-			       SHELL_CMD(get, NULL, "Get inverted polarity status",
-					 cmd_ship_config_inv_polarity_get),
-			       SHELL_CMD(set, NULL, "Set inverted polarity status",
-					 cmd_ship_config_inv_polarity_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 3 command) array for command "ship config". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ship_config,
-			       SHELL_CMD(time, &sub_ship_config_time, "Time", NULL),
-			       SHELL_CMD(inv_polarity, &sub_ship_config_inv_polarity,
-					 "Button invert polarity", NULL),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 4 command) array for command "ship reset long_press". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ship_reset_long_press,
-			       SHELL_CMD(get, NULL, "Get long press status",
-					 cmd_ship_reset_long_press_get),
-			       SHELL_CMD(set, NULL, "Set long press status",
-					 cmd_ship_reset_long_press_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 4 command) array for command "ship reset two_buttons". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ship_reset_two_buttons,
-			       SHELL_CMD(get, NULL, "Get two buttons status",
-					 cmd_ship_reset_two_buttons_get),
-			       SHELL_CMD(set, NULL, "Set two buttons status",
-					 cmd_ship_reset_two_buttons_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 3 command) array for command "ship reset". */
-SHELL_STATIC_SUBCMD_SET_CREATE(
-	sub_ship_reset, SHELL_CMD(long_press, &sub_ship_reset_long_press, "Long press", NULL),
-	SHELL_CMD(two_buttons, &sub_ship_reset_two_buttons, "Two buttons", NULL),
-	SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 3 command) array for command "ship mode". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ship_mode,
-			       SHELL_CMD(ship, NULL, "Enter ship mode", cmd_ship_mode_ship_set),
-			       SHELL_CMD(hibernate, NULL, "Enter hibernate mode",
-					 cmd_ship_mode_hibernate_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 2 command) array for command "ship". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ship, SHELL_CMD(config, &sub_ship_config, "Ship config", NULL),
-			       SHELL_CMD(reset, &sub_ship_reset, "Reset button config", NULL),
-			       SHELL_CMD(mode, &sub_ship_mode, "Set ship mode", NULL),
-			       SHELL_SUBCMD_SET_END);
-
 /* Creating subcommands (level 1 command) array for command "npmx". */
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_npmx, SHELL_CMD(adc, &sub_adc, "ADC", NULL), SHELL_CMD(buck, &sub_buck, "Buck", NULL),
@@ -4292,8 +4276,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD(errlog, &sub_errlog, "Reset errors logs", NULL),
 	SHELL_CMD(gpio, &sub_gpio, "GPIO", NULL), SHELL_CMD(ldsw, &sub_ldsw, "LDSW", NULL),
 	SHELL_CMD(led, &sub_led, "LED", NULL), SHELL_CMD(pof, &sub_pof, "POF", NULL),
-	SHELL_CMD(timer, &sub_timer, "Timer", NULL), SHELL_CMD(vbusin, &sub_vbusin, "VBUSIN", NULL),
-	SHELL_CMD(ship, &sub_ship, "SHIP", NULL),
+	SHELL_CMD(ship, &sub_ship, "SHIP", NULL), SHELL_CMD(timer, &sub_timer, "Timer", NULL),
+	SHELL_CMD(vbusin, &sub_vbusin, "VBUSIN", NULL),
 	SHELL_CMD(reset, NULL, "Restart device", cmd_reset), SHELL_SUBCMD_SET_END);
 
 /* Creating root (level 0) command "npmx" without a handler. */

--- a/drivers/npmx/npmx_shell.c
+++ b/drivers/npmx/npmx_shell.c
@@ -1081,214 +1081,34 @@ static int cmd_buck_vout_select_get(const struct shell *shell, size_t argc, char
 	return 0;
 }
 
-static int cmd_charger_termination_voltage_get(
-	const struct shell *shell, size_t argc, char **argv,
-	npmx_error_t (*func)(npmx_charger_t const *p_instance, npmx_charger_voltage_t *voltage))
+static int cmd_charger_charging_current_set(const struct shell *shell, size_t argc, char **argv)
 {
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
+	args_info_t args_info = { .expected_args = 1,
+				  .arg = {
+					  [0] = { SHELL_ARG_TYPE_UINT32_VALUE, "charging current" },
+				  } };
+	if (!arguments_check(shell, argc, argv, &args_info)) {
 		return 0;
 	}
 
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	npmx_charger_voltage_t voltage;
-
-	npmx_error_t err_code = func(charger_instance, &voltage);
-
-	if (check_error_code(shell, err_code)) {
-		uint32_t voltage_mv;
-
-		if (npmx_charger_voltage_convert_to_mv(voltage, &voltage_mv)) {
-			shell_print(shell, "Value: %d mV.", voltage_mv);
-		} else {
-			shell_error(
-				shell,
-				"Error: unable to convert battery termination voltage value to millivolts.");
-		}
-	} else {
-		shell_error(shell, "Error: unable to read battery termination voltage value.");
-	}
-
-	return 0;
-}
-
-static int cmd_charger_termination_voltage_set(
-	const struct shell *shell, size_t argc, char **argv,
-	npmx_error_t (*func)(npmx_charger_t const *p_instance, npmx_charger_voltage_t voltage))
-{
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
 		return 0;
 	}
 
-	if (argc < 2) {
-		shell_error(shell, "Error: missing termination voltage value.");
+	if (!charger_disabled_check(shell, charger_instance, "charging current")) {
 		return 0;
 	}
 
-	int err = 0;
-	uint32_t volt_set = (uint32_t)shell_strtoul(argv[1], 0, &err);
-
-	if (err != 0) {
-		shell_error(shell, "Error: voltage value has to be an integer.");
-		return 0;
-	}
-
-	npmx_charger_voltage_t voltage = npmx_charger_voltage_convert(volt_set);
-
-	if (voltage == NPMX_CHARGER_VOLTAGE_INVALID) {
-		shell_error(shell, "Error: wrong termination voltage value.");
-		return 0;
-	}
-
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	uint32_t modules_mask;
-	npmx_error_t err_code = npmx_charger_module_get(charger_instance, &modules_mask);
-
+	uint16_t charging_current_ma = CLAMP(args_info.arg[0].result.uvalue, 0, UINT16_MAX);
+	npmx_error_t err_code =
+		npmx_charger_charging_current_set(charger_instance, charging_current_ma);
 	if (!check_error_code(shell, err_code)) {
-		shell_error(shell, "Error: unable to get charger module status.");
+		print_set_error(shell, "charging current");
 		return 0;
 	}
 
-	if ((modules_mask & NPMX_CHARGER_MODULE_CHARGER_MASK) != 0) {
-		shell_error(shell,
-			    "Error: charger must be disabled to set battery termination voltage.");
-		return 0;
-	}
-
-	err_code = func(charger_instance, voltage);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Success: %s mV.", argv[1]);
-	} else {
-		shell_error(shell, "Error: unable to set battery termination voltage value.");
-	}
-
-	return 0;
-}
-
-static int cmd_charger_termination_voltage_normal_get(const struct shell *shell, size_t argc,
-						      char **argv)
-{
-	return cmd_charger_termination_voltage_get(shell, argc, argv,
-						   npmx_charger_termination_normal_voltage_get);
-}
-
-static int cmd_charger_termination_voltage_normal_set(const struct shell *shell, size_t argc,
-						      char **argv)
-{
-	return cmd_charger_termination_voltage_set(shell, argc, argv,
-						   npmx_charger_termination_normal_voltage_set);
-}
-
-static int cmd_charger_termination_voltage_warm_get(const struct shell *shell, size_t argc,
-						    char **argv)
-{
-	return cmd_charger_termination_voltage_get(shell, argc, argv,
-						   npmx_charger_termination_warm_voltage_get);
-}
-
-static int cmd_charger_termination_voltage_warm_set(const struct shell *shell, size_t argc,
-						    char **argv)
-{
-	return cmd_charger_termination_voltage_set(shell, argc, argv,
-						   npmx_charger_termination_warm_voltage_set);
-}
-
-static int cmd_charger_termination_current_get(const struct shell *shell, size_t argc, char **argv)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	npmx_charger_iterm_t current;
-
-	npmx_error_t err_code = npmx_charger_termination_current_get(charger_instance, &current);
-
-	if (check_error_code(shell, err_code)) {
-		uint32_t current_pct;
-
-		if (npmx_charger_iterm_convert_to_pct(current, &current_pct)) {
-			shell_print(shell, "Value: %d%%.", current_pct);
-		} else {
-			shell_error(
-				shell,
-				"Error: unable to convert battery termination current value to pct.");
-		}
-	} else {
-		shell_error(shell, "Error: unable to read battery termination current value.");
-	}
-
-	return 0;
-}
-
-static int cmd_charger_termination_current_set(const struct shell *shell, size_t argc, char **argv)
-{
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	if (argc < 2) {
-		shell_error(shell, "Error: missing termination current value.");
-		return 0;
-	}
-
-	int err = 0;
-	uint32_t curr_set = (uint32_t)shell_strtoul(argv[1], 0, &err);
-
-	if (err != 0) {
-		shell_error(shell, "Error: current has to be an integer.");
-		return 0;
-	}
-
-	npmx_charger_iterm_t current = npmx_charger_iterm_convert(curr_set);
-
-	if (current == NPMX_CHARGER_ITERM_INVALID) {
-		shell_error(
-			shell,
-			"Error: wrong termination current value, it should be equal to 10 or 20.");
-		return 0;
-	}
-
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	uint32_t modules_mask;
-	npmx_error_t err_code = npmx_charger_module_get(charger_instance, &modules_mask);
-
-	if (!check_error_code(shell, err_code)) {
-		shell_error(shell, "Error: unable to get charger module status.");
-		return 0;
-	}
-
-	if ((modules_mask & NPMX_CHARGER_MODULE_CHARGER_MASK) != 0) {
-		shell_error(shell, "Error: charger must be disabled to set termination current.");
-		return 0;
-	}
-
-	err_code = npmx_charger_termination_current_set(charger_instance, current);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Success: %s%%.", argv[1]);
-	} else {
-		shell_error(shell, "Error: unable to set charger termination current value.");
-	}
-
+	print_success(shell, charging_current_ma, UNIT_TYPE_MILLIAMPERE);
 	return 0;
 }
 
@@ -1297,70 +1117,525 @@ static int cmd_charger_charging_current_get(const struct shell *shell, size_t ar
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
 		return 0;
 	}
 
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-
-	uint16_t current;
-	npmx_error_t err_code = npmx_charger_charging_current_get(charger_instance, &current);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Value: %d mA.", current);
-	} else {
-		shell_error(shell, "Error: unable to read charging current value.");
+	uint16_t charging_current_ma;
+	npmx_error_t err_code =
+		npmx_charger_charging_current_get(charger_instance, &charging_current_ma);
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "charging current");
+		return 0;
 	}
 
+	print_value(shell, charging_current_ma, UNIT_TYPE_MILLIAMPERE);
 	return 0;
 }
 
-static int cmd_charger_charging_current_set(const struct shell *shell, size_t argc, char **argv)
+static int charger_die_temp_set(const struct shell *shell, size_t argc, char **argv,
+				npmx_error_t (*func)(npmx_charger_t const *p_instance,
+						     int16_t temperature))
 {
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
+	args_info_t args_info = { .expected_args = 1,
+				  .arg = {
+					  [0] = { SHELL_ARG_TYPE_INT32_VALUE,
+						  "die temperature threshold" },
+				  } };
+	if (!arguments_check(shell, argc, argv, &args_info)) {
 		return 0;
 	}
 
-	if (argc < 2) {
-		shell_error(shell, "Error: missing charging current value.");
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
 		return 0;
 	}
 
-	int err = 0;
-	uint16_t current = CLAMP(shell_strtoul(argv[1], 0, &err), 0, UINT16_MAX);
-
-	if (err != 0) {
-		shell_error(shell, "Error: current has to be an integer.");
+	if (!charger_disabled_check(shell, charger_instance, "die temperature threshold")) {
 		return 0;
 	}
 
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	uint32_t modules_mask;
-	npmx_error_t err_code = npmx_charger_module_get(charger_instance, &modules_mask);
+	int16_t temperature = CLAMP(args_info.arg[0].result.ivalue, 0, INT16_MAX);
+	if (temperature < NPM_BCHARGER_DIE_TEMPERATURE_MIN_VAL ||
+	    temperature > NPM_BCHARGER_DIE_TEMPERATURE_MAX_VAL) {
+		shell_error(shell, "Error: value out of range.");
+		return 0;
+	}
 
+	npmx_error_t err_code = func(charger_instance, temperature);
 	if (!check_error_code(shell, err_code)) {
-		shell_error(shell, "Error: unable to get charger module status.");
+		print_set_error(shell, "die temperature threshold");
 		return 0;
 	}
 
-	if ((modules_mask & NPMX_CHARGER_MODULE_CHARGER_MASK) != 0) {
-		shell_error(shell, "Error: charger must be disabled to set charging current.");
+	print_success(shell, temperature, UNIT_TYPE_CELSIUS);
+	return 0;
+}
+
+static int charger_die_temp_get(const struct shell *shell,
+				npmx_error_t (*func)(npmx_charger_t const *p_instance,
+						     int16_t *temperature))
+{
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
 		return 0;
 	}
 
-	err_code = npmx_charger_charging_current_set(charger_instance, current);
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Success: %s mA.", argv[1]);
-	} else {
-		shell_error(shell, "Error: unable to set charging current value.");
+	int16_t temperature;
+	npmx_error_t err_code = func(charger_instance, &temperature);
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "die temperature threshold");
+		return 0;
 	}
 
+	print_value(shell, temperature, UNIT_TYPE_CELSIUS);
+	return 0;
+}
+
+static int cmd_charger_die_temp_resume_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return charger_die_temp_set(shell, argc, argv, npmx_charger_die_temp_resume_set);
+}
+
+static int cmd_charger_die_temp_resume_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return charger_die_temp_get(shell, npmx_charger_die_temp_resume_get);
+}
+
+static int cmd_charger_die_temp_status_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
+		return 0;
+	}
+
+	bool status;
+	npmx_error_t err_code = npmx_charger_die_temp_status_get(charger_instance, &status);
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "charger die temperature comparator status");
+		return 0;
+	}
+
+	print_value(shell, status, UNIT_TYPE_NONE);
+	return 0;
+}
+
+static int cmd_charger_die_temp_stop_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return charger_die_temp_set(shell, argc, argv, npmx_charger_die_temp_stop_set);
+}
+
+static int cmd_charger_die_temp_stop_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return charger_die_temp_get(shell, npmx_charger_die_temp_stop_get);
+}
+
+static int cmd_charger_discharging_current_set(const struct shell *shell, size_t argc, char **argv)
+{
+	args_info_t args_info = { .expected_args = 1,
+				  .arg = {
+					  [0] = { SHELL_ARG_TYPE_UINT32_VALUE,
+						  "discharging current" },
+				  } };
+	if (!arguments_check(shell, argc, argv, &args_info)) {
+		return 0;
+	}
+
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
+		return 0;
+	}
+
+	if (!charger_disabled_check(shell, charger_instance, "discharging current")) {
+		return 0;
+	}
+
+	uint16_t discharging_current_ma = CLAMP(args_info.arg[0].result.uvalue, 0, UINT16_MAX);
+	npmx_error_t err_code =
+		npmx_charger_discharging_current_set(charger_instance, discharging_current_ma);
+	if (!check_error_code(shell, err_code)) {
+		print_set_error(shell, "discharging current");
+		return 0;
+	}
+
+	err_code = npmx_charger_discharging_current_get(charger_instance, &discharging_current_ma);
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "discharging current");
+		return 0;
+	}
+
+	print_success(shell, discharging_current_ma, UNIT_TYPE_MILLIAMPERE);
+	shell_print(shell, "Set value may be different than requested.");
+	return 0;
+}
+
+static int cmd_charger_discharging_current_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
+		return 0;
+	}
+
+	uint16_t charging_current_ma;
+	npmx_error_t err_code =
+		npmx_charger_discharging_current_get(charger_instance, &charging_current_ma);
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "discharging current");
+		return 0;
+	}
+
+	print_value(shell, charging_current_ma, UNIT_TYPE_MILLIAMPERE);
+	return 0;
+}
+
+static int charger_module_set(const struct shell *shell, size_t argc, char **argv,
+			      npmx_charger_module_mask_t mask)
+{
+	args_info_t args_info = { .expected_args = 1,
+				  .arg = {
+					  [0] = { SHELL_ARG_TYPE_BOOL_VALUE, "status" },
+				  } };
+	if (!arguments_check(shell, argc, argv, &args_info)) {
+		return 0;
+	}
+
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
+		return 0;
+	}
+
+	bool charger_set = args_info.arg[0].result.bvalue;
+
+	npmx_error_t (*change_status_function)(const npmx_charger_t *p_instance,
+					       uint32_t module_mask) =
+		charger_set ? npmx_charger_module_enable_set : npmx_charger_module_disable_set;
+
+	npmx_error_t err_code = change_status_function(charger_instance, mask);
+	if (!check_error_code(shell, err_code)) {
+		print_set_error(shell, "charging module status");
+		return 0;
+	}
+
+	print_success(shell, charger_set, UNIT_TYPE_NONE);
+	return 0;
+}
+
+static int charger_module_get(const struct shell *shell, npmx_charger_module_mask_t mask)
+{
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
+		return 0;
+	}
+
+	uint32_t module_mask;
+	npmx_error_t err_code = npmx_charger_module_get(charger_instance, &module_mask);
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "charging module status");
+		return 0;
+	}
+
+	print_value(shell, !!(module_mask & (uint32_t)mask), UNIT_TYPE_NONE);
+	return 0;
+}
+
+static int cmd_charger_module_charger_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return charger_module_set(shell, argc, argv, NPMX_CHARGER_MODULE_CHARGER_MASK);
+}
+
+static int cmd_charger_module_charger_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return charger_module_get(shell, NPMX_CHARGER_MODULE_CHARGER_MASK);
+}
+
+static int cmd_charger_module_full_cool_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return charger_module_set(shell, argc, argv, NPMX_CHARGER_MODULE_FULL_COOL_MASK);
+}
+
+static int cmd_charger_module_full_cool_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return charger_module_get(shell, NPMX_CHARGER_MODULE_FULL_COOL_MASK);
+}
+
+static int cmd_charger_module_ntc_limits_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return charger_module_set(shell, argc, argv, NPMX_CHARGER_MODULE_NTC_LIMITS_MASK);
+}
+
+static int cmd_charger_module_ntc_limits_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return charger_module_get(shell, NPMX_CHARGER_MODULE_NTC_LIMITS_MASK);
+}
+
+static int cmd_charger_module_recharge_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return charger_module_set(shell, argc, argv, NPMX_CHARGER_MODULE_RECHARGE_MASK);
+}
+
+static int cmd_charger_module_recharge_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return charger_module_get(shell, NPMX_CHARGER_MODULE_RECHARGE_MASK);
+}
+
+static int charger_ntc_resistance_set(const struct shell *shell, size_t argc, char **argv,
+				      npmx_error_t (*func)(npmx_charger_t const *p_instance,
+							   uint32_t p_resistance))
+{
+	args_info_t args_info = { .expected_args = 1,
+				  .arg = {
+					  [0] = { SHELL_ARG_TYPE_UINT32_VALUE, "NTC resistance" },
+				  } };
+	if (!arguments_check(shell, argc, argv, &args_info)) {
+		return 0;
+	}
+
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
+		return 0;
+	}
+
+	if (!charger_disabled_check(shell, charger_instance, "NTC resistance")) {
+		return 0;
+	}
+
+	uint32_t resistance = args_info.arg[0].result.uvalue;
+	npmx_error_t err_code = func(charger_instance, resistance);
+	if (!check_error_code(shell, err_code)) {
+		print_set_error(shell, "NTC resistance");
+		return 0;
+	}
+
+	print_success(shell, resistance, UNIT_TYPE_OHM);
+	return 0;
+}
+
+static int charger_ntc_resistance_get(const struct shell *shell,
+				      npmx_error_t (*func)(npmx_charger_t const *p_instance,
+							   uint32_t *resistance))
+{
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
+		return 0;
+	}
+
+	uint32_t resistance;
+	npmx_error_t err_code = func(charger_instance, &resistance);
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "NTC resistance");
+		return 0;
+	}
+
+	print_value(shell, resistance, UNIT_TYPE_OHM);
+	return 0;
+}
+
+static int cmd_charger_ntc_resistance_cold_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return charger_ntc_resistance_set(shell, argc, argv, npmx_charger_cold_resistance_set);
+}
+
+static int cmd_charger_ntc_resistance_cold_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return charger_ntc_resistance_get(shell, npmx_charger_cold_resistance_get);
+}
+
+static int cmd_charger_ntc_resistance_cool_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return charger_ntc_resistance_set(shell, argc, argv, npmx_charger_cool_resistance_set);
+}
+
+static int cmd_charger_ntc_resistance_cool_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return charger_ntc_resistance_get(shell, npmx_charger_cool_resistance_get);
+}
+
+static int cmd_charger_ntc_resistance_warm_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return charger_ntc_resistance_set(shell, argc, argv, npmx_charger_warm_resistance_set);
+}
+
+static int cmd_charger_ntc_resistance_warm_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return charger_ntc_resistance_get(shell, npmx_charger_warm_resistance_get);
+}
+
+static int cmd_charger_ntc_resistance_hot_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return charger_ntc_resistance_set(shell, argc, argv, npmx_charger_hot_resistance_set);
+}
+
+static int cmd_charger_ntc_resistance_hot_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return charger_ntc_resistance_get(shell, npmx_charger_hot_resistance_get);
+}
+
+static int charger_ntc_temperature_set(const struct shell *shell, size_t argc, char **argv,
+				       npmx_error_t (*func)(npmx_charger_t const *p_instance,
+							    int16_t temperature))
+{
+	args_info_t args_info = { .expected_args = 1,
+				  .arg = {
+					  [0] = { SHELL_ARG_TYPE_INT32_VALUE, "NTC temperature" },
+				  } };
+	if (!arguments_check(shell, argc, argv, &args_info)) {
+		return 0;
+	}
+
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
+		return 0;
+	}
+
+	if (!charger_disabled_check(shell, charger_instance, "NTC temperature")) {
+		return 0;
+	}
+
+	int32_t temperature = args_info.arg[0].result.ivalue;
+	if ((temperature < -20) || (temperature > 60)) {
+		shell_error(
+			shell,
+			"Error: The NTC temperature must be in the range between -20*C and 60*C.");
+		return 0;
+	}
+
+	npmx_error_t err_code = func(charger_instance, temperature);
+	if (!check_error_code(shell, err_code)) {
+		print_set_error(shell, "NTC temperature");
+		return 0;
+	}
+
+	print_success(shell, temperature, UNIT_TYPE_CELSIUS);
+	return 0;
+}
+
+static int charger_ntc_temperature_get(const struct shell *shell,
+				       npmx_error_t (*func)(npmx_charger_t const *p_instance,
+							    int16_t *p_temperature))
+{
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
+		return 0;
+	}
+
+	int16_t temperature;
+	npmx_error_t err_code = func(charger_instance, &temperature);
+	if (!check_error_code(shell, err_code)) {
+		print_set_error(shell, "NTC temperature");
+		return 0;
+	}
+
+	print_value(shell, temperature, UNIT_TYPE_CELSIUS);
+	return 0;
+}
+
+static int cmd_charger_ntc_temperature_cold_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return charger_ntc_temperature_set(shell, argc, argv, npmx_charger_cold_temperature_set);
+}
+
+static int cmd_charger_ntc_temperature_cold_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return charger_ntc_temperature_get(shell, npmx_charger_cold_temperature_get);
+}
+
+static int cmd_charger_ntc_temperature_cool_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return charger_ntc_temperature_set(shell, argc, argv, npmx_charger_cool_temperature_set);
+}
+
+static int cmd_charger_ntc_temperature_cool_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return charger_ntc_temperature_get(shell, npmx_charger_cool_temperature_get);
+}
+
+static int cmd_charger_ntc_temperature_warm_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return charger_ntc_temperature_set(shell, argc, argv, npmx_charger_warm_temperature_set);
+}
+
+static int cmd_charger_ntc_temperature_warm_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return charger_ntc_temperature_get(shell, npmx_charger_warm_temperature_get);
+}
+
+static int cmd_charger_ntc_temperature_hot_set(const struct shell *shell, size_t argc, char **argv)
+{
+	return charger_ntc_temperature_set(shell, argc, argv, npmx_charger_hot_temperature_set);
+}
+
+static int cmd_charger_ntc_temperature_hot_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return charger_ntc_temperature_get(shell, npmx_charger_hot_temperature_get);
+}
+
+static int cmd_charger_status_all_get(const struct shell *shell, size_t argc, char **argv)
+{
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
+		return 0;
+	}
+
+	uint8_t status_mask;
+	npmx_error_t err_code = npmx_charger_status_get(charger_instance, &status_mask);
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "charger status");
+		return 0;
+	}
+
+	print_value(shell, status_mask, UNIT_TYPE_NONE);
 	return 0;
 }
 
@@ -1369,682 +1644,249 @@ static int cmd_charger_status_charging_get(const struct shell *shell, size_t arg
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
 		return 0;
 	}
-
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
 
 	uint8_t status_mask;
 	uint8_t charging_mask = NPMX_CHARGER_STATUS_TRICKLE_CHARGE_MASK |
 				NPMX_CHARGER_STATUS_CONSTANT_CURRENT_MASK |
 				NPMX_CHARGER_STATUS_CONSTANT_VOLTAGE_MASK;
 	npmx_error_t err_code = npmx_charger_status_get(charger_instance, &status_mask);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Value: %d.", !!(status_mask & charging_mask));
-	} else {
-		shell_error(shell, "Error: unable to read charging status.");
-	}
-
-	return 0;
-}
-
-static int cmd_charger_status_get(const struct shell *shell, size_t argc, char **argv)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-
-	uint8_t status_mask;
-	npmx_error_t err_code = npmx_charger_status_get(charger_instance, &status_mask);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Value: %d.", status_mask);
-	} else {
-		shell_error(shell, "Error: unable to read charger status.");
-	}
-
-	return 0;
-}
-
-static int cmd_charger_module_set(const struct shell *shell, size_t argc, char **argv,
-				  npmx_charger_module_mask_t mask)
-{
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	if (argc < 2) {
-		shell_error(shell, "Error: missing new status value.");
-		return 0;
-	}
-
-	int err = 0;
-	uint8_t charger_set = CLAMP(shell_strtoul(argv[1], 0, &err), 0, UINT8_MAX);
-
-	if (err != 0) {
-		shell_error(shell, "Error: status has to be an integer.");
-		return 0;
-	}
-
-	if (charger_set > 1) {
-		shell_error(shell, "Error: wrong new status value.");
-		return 0;
-	}
-
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	npmx_error_t (*change_status_function)(const npmx_charger_t *p_instance,
-					       uint32_t module_mask) =
-		charger_set == 1 ? npmx_charger_module_enable_set : npmx_charger_module_disable_set;
-
-	npmx_error_t err_code = change_status_function(charger_instance, mask);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Success: %d.", charger_set);
-	} else {
-		shell_error(shell, "Error: unable to set charging module status.");
-	}
-
-	return 0;
-}
-
-static int cmd_charger_module_get(const struct shell *shell, size_t argc, char **argv,
-				  npmx_charger_module_mask_t mask)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	uint32_t module_mask;
-
-	npmx_error_t err_code = npmx_charger_module_get(charger_instance, &module_mask);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Value: %d.", !!(module_mask & (uint32_t)mask));
-	} else {
-		shell_error(shell, "Error: unable to read charging module status.");
-	}
-
-	return 0;
-}
-
-static int cmd_charger_module_charger_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return cmd_charger_module_set(shell, argc, argv, NPMX_CHARGER_MODULE_CHARGER_MASK);
-}
-
-static int cmd_charger_module_charger_get(const struct shell *shell, size_t argc, char **argv)
-{
-	return cmd_charger_module_get(shell, argc, argv, NPMX_CHARGER_MODULE_CHARGER_MASK);
-}
-
-static int cmd_charger_module_recharge_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return cmd_charger_module_set(shell, argc, argv, NPMX_CHARGER_MODULE_RECHARGE_MASK);
-}
-
-static int cmd_charger_module_recharge_get(const struct shell *shell, size_t argc, char **argv)
-{
-	return cmd_charger_module_get(shell, argc, argv, NPMX_CHARGER_MODULE_RECHARGE_MASK);
-}
-
-static int cmd_charger_module_ntc_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return cmd_charger_module_set(shell, argc, argv, NPMX_CHARGER_MODULE_NTC_LIMITS_MASK);
-}
-
-static int cmd_charger_module_ntc_get(const struct shell *shell, size_t argc, char **argv)
-{
-	return cmd_charger_module_get(shell, argc, argv, NPMX_CHARGER_MODULE_NTC_LIMITS_MASK);
-}
-
-static int cmd_charger_module_full_cool_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return cmd_charger_module_set(shell, argc, argv, NPMX_CHARGER_MODULE_FULL_COOL_MASK);
-}
-
-static int cmd_charger_module_full_cool_get(const struct shell *shell, size_t argc, char **argv)
-{
-	return cmd_charger_module_get(shell, argc, argv, NPMX_CHARGER_MODULE_FULL_COOL_MASK);
-}
-
-static int cmd_charger_trickle_get(const struct shell *shell, size_t argc, char **argv)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	npmx_charger_trickle_t voltage;
-
-	npmx_error_t err_code = npmx_charger_trickle_voltage_get(charger_instance, &voltage);
-
-	if (check_error_code(shell, err_code)) {
-		uint32_t voltage_mv;
-
-		if (npmx_charger_trickle_convert_to_mv(voltage, &voltage_mv)) {
-			shell_print(shell, "Value: %d mV.", voltage_mv);
-		} else {
-			shell_error(
-				shell,
-				"Error: unable to convert trickle voltage value to millivolts.");
-		}
-	} else {
-		shell_error(shell, "Error: unable to read trickle voltage value.");
-	}
-
-	return 0;
-}
-
-static int cmd_charger_trickle_set(const struct shell *shell, size_t argc, char **argv, void *data)
-{
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	npmx_charger_trickle_t charger_trickle = (npmx_charger_trickle_t)data;
-
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	uint32_t modules_mask;
-	npmx_error_t err_code = npmx_charger_module_get(charger_instance, &modules_mask);
-
 	if (!check_error_code(shell, err_code)) {
-		shell_error(shell, "Error: unable to get charger module status.");
+		print_get_error(shell, "charger status");
 		return 0;
 	}
 
-	if ((modules_mask & NPMX_CHARGER_MODULE_CHARGER_MASK) != 0) {
-		shell_error(shell, "Error: charger must be disabled to set trickle voltage.");
-		return 0;
-	}
-
-	uint32_t trickle_mv;
-
-	if (!npmx_charger_trickle_convert_to_mv(charger_trickle, &trickle_mv)) {
-		shell_error(shell, "Error: unable to convert trickle voltage value to millivolts.");
-	}
-
-	err_code = npmx_charger_trickle_voltage_set(charger_instance, charger_trickle);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Success: %d mV.", trickle_mv);
-	} else {
-		shell_error(shell, "Error: unable to set trickle voltage value.");
-	}
-
+	print_value(shell, !!(status_mask & charging_mask), UNIT_TYPE_NONE);
 	return 0;
 }
 
-static int cmd_die_temp_set(const struct shell *shell, size_t argc, char **argv,
-			    npmx_error_t (*func)(npmx_charger_t const *p_instance,
-						 int16_t temperature))
+static int cmd_charger_termination_current_set(const struct shell *shell, size_t argc, char **argv)
 {
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
+	args_info_t args_info = { .expected_args = 1,
+				  .arg = {
+					  [0] = { SHELL_ARG_TYPE_UINT32_VALUE,
+						  "termination current" },
+				  } };
+	if (!arguments_check(shell, argc, argv, &args_info)) {
 		return 0;
 	}
 
-	if (argc < 2) {
-		shell_error(shell, "Error: missing die temperature threshold value.");
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
 		return 0;
 	}
 
-	int err = 0;
-	int16_t temperature =
-		(int16_t)CLAMP(shell_strtol(argv[1], 0, &err), NPM_BCHARGER_DIE_TEMPERATURE_MIN_VAL,
-			       NPM_BCHARGER_DIE_TEMPERATURE_MAX_VAL);
-
-	if (err != 0) {
-		shell_error(shell, "Error: temperature has to be an integer.");
+	if (!charger_disabled_check(shell, charger_instance, "termination current")) {
 		return 0;
 	}
 
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	uint32_t modules_mask;
-	npmx_error_t err_code = npmx_charger_module_get(charger_instance, &modules_mask);
+	uint32_t current_pct = args_info.arg[0].result.uvalue;
+	npmx_charger_iterm_t charger_iterm = npmx_charger_iterm_convert(current_pct);
+	if (charger_iterm == NPMX_CHARGER_ITERM_INVALID) {
+		print_convert_error(shell, "pct", "termination current");
+		return 0;
+	}
 
+	npmx_error_t err_code =
+		npmx_charger_termination_current_set(charger_instance, charger_iterm);
 	if (!check_error_code(shell, err_code)) {
-		shell_error(shell, "Error: unable to get charger module status.");
+		print_set_error(shell, "termination current");
 		return 0;
 	}
 
-	if ((modules_mask & NPMX_CHARGER_MODULE_CHARGER_MASK) != 0) {
-		shell_error(shell, "Error: charger must be disabled to set threshold value.");
-		return 0;
-	}
-
-	err_code = func(charger_instance, temperature);
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Success: %d *C.", temperature);
-	} else {
-		shell_error(shell, "Error: unable to set die temperature threshold.");
-	}
-
+	print_success(shell, current_pct, UNIT_TYPE_PCT);
 	return 0;
 }
 
-static int cmd_die_temp_get(const struct shell *shell, size_t argc, char **argv,
-			    npmx_error_t (*func)(npmx_charger_t const *p_instance,
-						 int16_t *temperature))
+static int cmd_charger_termination_current_get(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
 		return 0;
 	}
 
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	int16_t temperature;
-
-	npmx_error_t err_code = func(charger_instance, &temperature);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Value: %d *C.", temperature);
-	} else {
-		shell_error(shell, "Error: unable to read die temperature threshold.");
+	npmx_charger_iterm_t charger_iterm;
+	npmx_error_t err_code =
+		npmx_charger_termination_current_get(charger_instance, &charger_iterm);
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "termination current");
+		return 0;
 	}
 
+	uint32_t current_pct;
+	if (!npmx_charger_iterm_convert_to_pct(charger_iterm, &current_pct)) {
+		print_convert_error(shell, "termination current", "pct");
+		return 0;
+	}
+
+	print_value(shell, current_pct, UNIT_TYPE_PCT);
 	return 0;
 }
 
-static int cmd_die_temp_resume_set(const struct shell *shell, size_t argc, char **argv)
+static int charger_termination_voltage_set(const struct shell *shell, size_t argc, char **argv,
+					   npmx_error_t (*func)(npmx_charger_t const *p_instance,
+								npmx_charger_voltage_t voltage))
 {
-	return cmd_die_temp_set(shell, argc, argv, npmx_charger_die_temp_resume_set);
+	args_info_t args_info = { .expected_args = 1,
+				  .arg = {
+					  [0] = { SHELL_ARG_TYPE_UINT32_VALUE,
+						  "termination voltage" },
+				  } };
+	if (!arguments_check(shell, argc, argv, &args_info)) {
+		return 0;
+	}
+
+	uint32_t voltage_mv = args_info.arg[0].result.uvalue;
+	npmx_charger_voltage_t charger_voltage = npmx_charger_voltage_convert(voltage_mv);
+	if (charger_voltage == NPMX_CHARGER_VOLTAGE_INVALID) {
+		print_convert_error(shell, "millivolts", "termination voltage");
+		return 0;
+	}
+
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
+		return 0;
+	}
+
+	if (!charger_disabled_check(shell, charger_instance, "termination voltage")) {
+		return 0;
+	}
+
+	npmx_error_t err_code = func(charger_instance, charger_voltage);
+	if (!check_error_code(shell, err_code)) {
+		print_set_error(shell, "termination voltage");
+		return 0;
+	}
+
+	print_success(shell, voltage_mv, UNIT_TYPE_MILLIVOLT);
+	return 0;
 }
 
-static int cmd_die_temp_resume_get(const struct shell *shell, size_t argc, char **argv)
+static int charger_termination_voltage_get(const struct shell *shell,
+					   npmx_error_t (*func)(npmx_charger_t const *p_instance,
+								npmx_charger_voltage_t *voltage))
 {
-	return cmd_die_temp_get(shell, argc, argv, npmx_charger_die_temp_resume_get);
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
+		return 0;
+	}
+
+	npmx_charger_voltage_t charger_voltage;
+	npmx_error_t err_code = func(charger_instance, &charger_voltage);
+	if (!check_error_code(shell, err_code)) {
+		print_get_error(shell, "termination voltage");
+		return 0;
+	}
+
+	uint32_t voltage_mv;
+	if (!npmx_charger_voltage_convert_to_mv(charger_voltage, &voltage_mv)) {
+		print_convert_error(shell, "termination voltage", "millivolts");
+		return 0;
+	}
+
+	print_value(shell, voltage_mv, UNIT_TYPE_MILLIVOLT);
+	return 0;
 }
 
-static int cmd_die_temp_stop_set(const struct shell *shell, size_t argc, char **argv)
+static int cmd_charger_termination_voltage_normal_set(const struct shell *shell, size_t argc,
+						      char **argv)
 {
-	return cmd_die_temp_set(shell, argc, argv, npmx_charger_die_temp_stop_set);
+	return charger_termination_voltage_set(shell, argc, argv,
+					       npmx_charger_termination_normal_voltage_set);
 }
 
-static int cmd_die_temp_stop_get(const struct shell *shell, size_t argc, char **argv)
-{
-	return cmd_die_temp_get(shell, argc, argv, npmx_charger_die_temp_stop_get);
-}
-
-static int cmd_die_temp_status_get(const struct shell *shell, size_t argc, char **argv)
+static int cmd_charger_termination_voltage_normal_get(const struct shell *shell, size_t argc,
+						      char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	bool status;
-
-	npmx_error_t err_code = npmx_charger_die_temp_status_get(charger_instance, &status);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Value: %d.", status);
-	} else {
-		shell_error(shell,
-			    "Error: unable to read charger die temperature comparator status.");
-	}
-
-	return 0;
+	return charger_termination_voltage_get(shell, npmx_charger_termination_normal_voltage_get);
 }
 
-static int cmd_ntc_resistance_set(const struct shell *shell, size_t argc, char **argv,
-				  npmx_error_t (*func)(npmx_charger_t const *p_instance,
-						       uint32_t p_resistance))
+static int cmd_charger_termination_voltage_warm_set(const struct shell *shell, size_t argc,
+						    char **argv)
 {
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	if (argc < 2) {
-		shell_error(shell, "Error: missing NTC resistance value.");
-		return 0;
-	}
-
-	int err = 0;
-	uint32_t resistance = shell_strtoul(argv[1], 0, &err);
-
-	if (err != 0) {
-		shell_error(shell, "Error: resistance has to be an integer.");
-		return 0;
-	}
-
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	uint32_t modules_mask;
-	npmx_error_t err_code = npmx_charger_module_get(charger_instance, &modules_mask);
-
-	if (!check_error_code(shell, err_code)) {
-		shell_error(shell, "Error: unable to get charger module status.");
-		return 0;
-	}
-
-	if ((modules_mask & NPMX_CHARGER_MODULE_CHARGER_MASK) != 0) {
-		shell_error(shell, "Error: charger must be disabled to set NTC resistance value.");
-		return 0;
-	}
-
-	err_code = func(charger_instance, resistance);
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Success: %d Ohm.", resistance);
-	} else {
-		shell_error(shell, "Error: unable to set NTC resistance value.");
-	}
-
-	return 0;
+	return charger_termination_voltage_set(shell, argc, argv,
+					       npmx_charger_termination_warm_voltage_set);
 }
 
-static int cmd_ntc_resistance_get(const struct shell *shell, size_t argc, char **argv,
-				  npmx_error_t (*func)(npmx_charger_t const *p_instance,
-						       uint32_t *resistance))
+static int cmd_charger_termination_voltage_warm_get(const struct shell *shell, size_t argc,
+						    char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
+	return charger_termination_voltage_get(shell, npmx_charger_termination_warm_voltage_get);
+}
 
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
+static int cmd_charger_trickle_voltage_set(const struct shell *shell, size_t argc, char **argv)
+{
+	args_info_t args_info = { .expected_args = 1,
+				  .arg = {
+					  [0] = { SHELL_ARG_TYPE_UINT32_VALUE, "trickle voltage" },
+				  } };
+	if (!arguments_check(shell, argc, argv, &args_info)) {
 		return 0;
 	}
 
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	uint32_t resistance;
-
-	npmx_error_t err_code = func(charger_instance, &resistance);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Value: %d Ohm.", resistance);
-	} else {
-		shell_error(shell, "Error: unable to read NTC resistance value.");
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
+		return 0;
 	}
 
+	if (!charger_disabled_check(shell, charger_instance, "trickle voltage")) {
+		return 0;
+	}
+
+	uint32_t voltage_mv = args_info.arg[0].result.uvalue;
+	npmx_charger_trickle_t charger_trickle = npmx_charger_trickle_convert(voltage_mv);
+	if (charger_trickle == NPMX_CHARGER_TRICKLE_INVALID) {
+		print_convert_error(shell, "millivolts", "trickle voltage");
+		return 0;
+	}
+
+	npmx_error_t err_code = npmx_charger_trickle_voltage_set(charger_instance, charger_trickle);
+	if (!check_error_code(shell, err_code)) {
+		print_set_error(shell, "trickle voltage");
+		return 0;
+	}
+
+	print_success(shell, voltage_mv, UNIT_TYPE_MILLIVOLT);
 	return 0;
 }
 
-static int cmd_ntc_resistance_cold_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return cmd_ntc_resistance_set(shell, argc, argv, npmx_charger_cold_resistance_set);
-}
-
-static int cmd_ntc_resistance_cold_get(const struct shell *shell, size_t argc, char **argv)
-{
-	return cmd_ntc_resistance_get(shell, argc, argv, npmx_charger_cold_resistance_get);
-}
-
-static int cmd_ntc_resistance_cool_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return cmd_ntc_resistance_set(shell, argc, argv, npmx_charger_cool_resistance_set);
-}
-
-static int cmd_ntc_resistance_cool_get(const struct shell *shell, size_t argc, char **argv)
-{
-	return cmd_ntc_resistance_get(shell, argc, argv, npmx_charger_cool_resistance_get);
-}
-
-static int cmd_ntc_resistance_warm_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return cmd_ntc_resistance_set(shell, argc, argv, npmx_charger_warm_resistance_set);
-}
-
-static int cmd_ntc_resistance_warm_get(const struct shell *shell, size_t argc, char **argv)
-{
-	return cmd_ntc_resistance_get(shell, argc, argv, npmx_charger_warm_resistance_get);
-}
-
-static int cmd_ntc_resistance_hot_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return cmd_ntc_resistance_set(shell, argc, argv, npmx_charger_hot_resistance_set);
-}
-
-static int cmd_ntc_resistance_hot_get(const struct shell *shell, size_t argc, char **argv)
-{
-	return cmd_ntc_resistance_get(shell, argc, argv, npmx_charger_hot_resistance_get);
-}
-
-static int ntc_temperature_get(const struct shell *shell, size_t argc, char **argv,
-			       npmx_error_t (*func)(npmx_charger_t const *p_instance,
-						    int16_t *p_temperature))
+static int cmd_charger_trickle_voltage_get(const struct shell *shell, size_t argc, char **argv)
 {
 	ARG_UNUSED(argc);
 	ARG_UNUSED(argv);
 
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
+	npmx_charger_t *charger_instance = charger_instance_get(shell);
+	if (charger_instance == NULL) {
 		return 0;
 	}
 
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	int16_t temperature;
-	npmx_error_t err_code = func(charger_instance, &temperature);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Value: %d *C.", temperature);
-	} else {
-		shell_error(shell, "Error: unable to get temperature value.");
-	}
-
-	return 0;
-}
-
-static int ntc_temperature_set(const struct shell *shell, size_t argc, char **argv,
-			       npmx_error_t (*func)(npmx_charger_t const *p_instance,
-						    int16_t temperature))
-{
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	if (argc < 2) {
-		shell_error(shell, "Error: missing NTC temperature value.");
-		return 0;
-	}
-
-	int err = 0;
-	int32_t temperature = shell_strtol(argv[1], 0, &err);
-
-	if (err != 0) {
-		shell_error(shell, "Error: NTC temperature has to be an integer.");
-		return 0;
-	}
-
-	if ((temperature < -20) || (temperature > 60)) {
-		shell_error(
-			shell,
-			"Error: The NTC temperature must be in the range between -20*C and 60*C.");
-		return 0;
-	}
-
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	uint32_t modules_mask;
-	npmx_error_t err_code = npmx_charger_module_get(charger_instance, &modules_mask);
-
+	npmx_charger_trickle_t charger_trickle;
+	npmx_error_t err_code =
+		npmx_charger_trickle_voltage_get(charger_instance, &charger_trickle);
 	if (!check_error_code(shell, err_code)) {
-		shell_error(shell, "Error: unable to get charger module status.");
+		print_get_error(shell, "trickle voltage");
 		return 0;
 	}
 
-	if ((modules_mask & NPMX_CHARGER_MODULE_CHARGER_MASK) != 0) {
-		shell_error(shell, "Error: charger must be disabled to set NTC temperature value.");
+	uint32_t voltage_mv;
+	if (!npmx_charger_trickle_convert_to_mv(charger_trickle, &voltage_mv)) {
+		print_convert_error(shell, "trickle voltage", "millivolts");
 		return 0;
 	}
 
-	err_code = func(charger_instance, temperature);
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Success: %d *C.", temperature);
-	} else {
-		shell_error(shell, "Error: unable to set NTC temperature value.");
-	}
-
-	return 0;
-}
-
-static int cmd_ntc_temperature_cold_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return ntc_temperature_set(shell, argc, argv, npmx_charger_cold_temperature_set);
-}
-
-static int cmd_ntc_temperature_cold_get(const struct shell *shell, size_t argc, char **argv)
-{
-	return ntc_temperature_get(shell, argc, argv, npmx_charger_cold_temperature_get);
-}
-
-static int cmd_ntc_temperature_cool_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return ntc_temperature_set(shell, argc, argv, npmx_charger_cool_temperature_set);
-}
-
-static int cmd_ntc_temperature_cool_get(const struct shell *shell, size_t argc, char **argv)
-{
-	return ntc_temperature_get(shell, argc, argv, npmx_charger_cool_temperature_get);
-}
-
-static int cmd_ntc_temperature_warm_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return ntc_temperature_set(shell, argc, argv, npmx_charger_warm_temperature_set);
-}
-
-static int cmd_ntc_temperature_warm_get(const struct shell *shell, size_t argc, char **argv)
-{
-	return ntc_temperature_get(shell, argc, argv, npmx_charger_warm_temperature_get);
-}
-
-static int cmd_ntc_temperature_hot_set(const struct shell *shell, size_t argc, char **argv)
-{
-	return ntc_temperature_set(shell, argc, argv, npmx_charger_hot_temperature_set);
-}
-
-static int cmd_ntc_temperature_hot_get(const struct shell *shell, size_t argc, char **argv)
-{
-	return ntc_temperature_get(shell, argc, argv, npmx_charger_hot_temperature_get);
-}
-
-static int cmd_charger_discharging_current_get(const struct shell *shell, size_t argc, char **argv)
-{
-	ARG_UNUSED(argc);
-	ARG_UNUSED(argv);
-
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	uint16_t current;
-	npmx_error_t err_code = npmx_charger_discharging_current_get(charger_instance, &current);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Value: %u mA.", current);
-	} else {
-		shell_error(shell, "Error: unable to read trickle voltage value.");
-	}
-
-	return 0;
-}
-
-static int cmd_charger_discharging_current_set(const struct shell *shell, size_t argc, char **argv)
-{
-	npmx_instance_t *npmx_instance = npmx_driver_instance_get(pmic_dev);
-
-	if (npmx_instance == NULL) {
-		shell_error(shell, "Error: shell is not initialized.");
-		return 0;
-	}
-
-	if (argc < 2) {
-		shell_error(shell, "Error: missing current value.");
-		return 0;
-	}
-
-	int err = 0;
-	uint16_t discharging_current = CLAMP(shell_strtoul(argv[1], 0, &err), 0, UINT16_MAX);
-
-	if (err != 0) {
-		shell_error(shell, "Error: current has to be an integer.");
-		return 0;
-	}
-
-	npmx_charger_t *charger_instance = npmx_charger_get(npmx_instance, 0);
-	uint32_t modules_mask;
-	npmx_error_t err_code = npmx_charger_module_get(charger_instance, &modules_mask);
-
-	if (!check_error_code(shell, err_code)) {
-		shell_error(shell, "Error: unable to get charger module status.");
-		return 0;
-	}
-
-	if ((modules_mask & NPMX_CHARGER_MODULE_CHARGER_MASK) != 0) {
-		shell_error(shell, "Error: charger must be disabled to set discharging current.");
-		return 0;
-	}
-
-	err_code = npmx_charger_discharging_current_set(charger_instance, discharging_current);
-
-	if (!check_error_code(shell, err_code)) {
-		shell_error(shell, "Error: unable to set discharging current value.");
-	}
-
-	err_code = npmx_charger_discharging_current_get(charger_instance, &discharging_current);
-
-	if (check_error_code(shell, err_code)) {
-		shell_print(shell, "Success: %d mA.", discharging_current);
-		shell_print(shell, "Set value may be different than requested.");
-	} else {
-		shell_error(shell, "Error: unable to get discharging current value.");
-	}
-
+	print_value(shell, voltage_mv, UNIT_TYPE_MILLIVOLT);
 	return 0;
 }
 
@@ -4201,44 +4043,190 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_buck,
 					 "Buck output voltage reference source", NULL),
 			       SHELL_SUBCMD_SET_END);
 
-/* Creating subcommands (level 4 command) array for command "charger termination_voltage normal". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_termination_voltage_normal,
-			       SHELL_CMD(get, NULL, "Get charger normal termination voltage",
-					 cmd_charger_termination_voltage_normal_get),
-			       SHELL_CMD(set, NULL, "Set charger normal termination voltage",
-					 cmd_charger_termination_voltage_normal_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 4 command) array for command "charger termination_voltage warm". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_termination_voltage_warm,
-			       SHELL_CMD(get, NULL, "Get charger warm termination voltage",
-					 cmd_charger_termination_voltage_warm_get),
-			       SHELL_CMD(set, NULL, "Set charger warm termination voltage",
-					 cmd_charger_termination_voltage_warm_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 3 command) array for command "charger termination_voltage". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_termination_voltage,
-			       SHELL_CMD(normal, &sub_charger_termination_voltage_normal,
-					 "Charger normal termination voltage", NULL),
-			       SHELL_CMD(warm, &sub_charger_termination_voltage_warm,
-					 "Charger warm termination voltage", NULL),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 3 command) array for command "charger termination_current". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_termination_current,
-			       SHELL_CMD(get, NULL, "Get charger termination current",
-					 cmd_charger_termination_current_get),
-			       SHELL_CMD(set, NULL, "Set charger termination current",
-					 cmd_charger_termination_current_set),
-			       SHELL_SUBCMD_SET_END);
-
 /* Creating subcommands (level 3 command) array for command "charger charging_current". */
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_charging_current,
-			       SHELL_CMD(get, NULL, "Get charging current",
-					 cmd_charger_charging_current_get),
 			       SHELL_CMD(set, NULL, "Set charging current",
 					 cmd_charger_charging_current_set),
+			       SHELL_CMD(get, NULL, "Get charging current",
+					 cmd_charger_charging_current_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "charger die_temp resume". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_die_temp_resume,
+			       SHELL_CMD(set, NULL,
+					 "Set die temperature threshold for resume charging",
+					 cmd_charger_die_temp_resume_set),
+			       SHELL_CMD(get, NULL,
+					 "Get die temperature threshold for resume charging",
+					 cmd_charger_die_temp_resume_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "charger die_temp status". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_die_temp_status,
+			       SHELL_CMD(get, NULL, "Get die temperature comparator status",
+					 cmd_charger_die_temp_status_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "charger die_temp stop". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_die_temp_stop,
+			       SHELL_CMD(set, NULL,
+					 "Set die temperature threshold for stop charging",
+					 cmd_charger_die_temp_stop_set),
+			       SHELL_CMD(get, NULL,
+					 "Get die temperature threshold for stop charging",
+					 cmd_charger_die_temp_stop_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 3 command) array for command "charger die_temp". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_die_temp,
+			       SHELL_CMD(resume, &sub_charger_die_temp_resume,
+					 "Die temperature threshold for resume charging", NULL),
+			       SHELL_CMD(status, &sub_charger_die_temp_status,
+					 "Die temperature comparator status", NULL),
+			       SHELL_CMD(stop, &sub_charger_die_temp_stop,
+					 "Die temperature threshold for stop charging", NULL),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 3 command) array for command "charger discharging_current". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_discharging_current,
+			       SHELL_CMD(set, NULL, "Set discharging current",
+					 cmd_charger_discharging_current_set),
+			       SHELL_CMD(get, NULL, "Get discharging current",
+					 cmd_charger_discharging_current_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "charger module charger". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_module_charger,
+			       SHELL_CMD(set, NULL, "Set charger status",
+					 cmd_charger_module_charger_set),
+			       SHELL_CMD(get, NULL, "Get charger status",
+					 cmd_charger_module_charger_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "charger module full_cool". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_module_full_cool,
+			       SHELL_CMD(set, NULL, "Set full cool status",
+					 cmd_charger_module_full_cool_set),
+			       SHELL_CMD(get, NULL, "Get full cool status",
+					 cmd_charger_module_full_cool_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "charger module ntc_limits". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_module_ntc_limits,
+			       SHELL_CMD(set, NULL, "Set NTC status",
+					 cmd_charger_module_ntc_limits_set),
+			       SHELL_CMD(get, NULL, "Get NTC status",
+					 cmd_charger_module_ntc_limits_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "charger module recharge". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_module_recharge,
+			       SHELL_CMD(set, NULL, "Set recharge status",
+					 cmd_charger_module_recharge_set),
+			       SHELL_CMD(get, NULL, "Get recharge status",
+					 cmd_charger_module_recharge_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 3 command) array for command "charger module". */
+SHELL_STATIC_SUBCMD_SET_CREATE(
+	sub_charger_module, SHELL_CMD(charger, &sub_charger_module_charger, "Charger module", NULL),
+	SHELL_CMD(full_cool, &sub_charger_module_full_cool, "Full charge in cool temp module",
+		  NULL),
+	SHELL_CMD(ntc_limits, &sub_charger_module_ntc_limits, "NTC limits module", NULL),
+	SHELL_CMD(recharge, &sub_charger_module_recharge, "Recharge module", NULL),
+	SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "charger ntc_resistance cold". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_ntc_resistance_cold,
+			       SHELL_CMD(set, NULL, "Set NTC resistance",
+					 cmd_charger_ntc_resistance_cold_set),
+			       SHELL_CMD(get, NULL, "Get NTC resistance",
+					 cmd_charger_ntc_resistance_cold_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "charger ntc_resistance cool". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_ntc_resistance_cool,
+			       SHELL_CMD(set, NULL, "Set NTC resistance",
+					 cmd_charger_ntc_resistance_cool_set),
+			       SHELL_CMD(get, NULL, "Get NTC resistance",
+					 cmd_charger_ntc_resistance_cool_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "charger ntc_resistance warm". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_ntc_resistance_warm,
+			       SHELL_CMD(set, NULL, "Set NTC resistance",
+					 cmd_charger_ntc_resistance_warm_set),
+			       SHELL_CMD(get, NULL, "Get NTC resistance",
+					 cmd_charger_ntc_resistance_warm_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "charger ntc_resistance hot". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_ntc_resistance_hot,
+			       SHELL_CMD(set, NULL, "Set NTC resistance",
+					 cmd_charger_ntc_resistance_hot_set),
+			       SHELL_CMD(get, NULL, "Get NTC resistance",
+					 cmd_charger_ntc_resistance_hot_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 3 command) array for command "charger ntc_resistance". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_ntc_resistance,
+			       SHELL_CMD(cold, &sub_charger_ntc_resistance_cold,
+					 "NTC resistance when cold temperature", NULL),
+			       SHELL_CMD(cool, &sub_charger_ntc_resistance_cool,
+					 "NTC resistance when cool temperature", NULL),
+			       SHELL_CMD(warm, &sub_charger_ntc_resistance_warm,
+					 "NTC resistance when warm temperature", NULL),
+			       SHELL_CMD(hot, &sub_charger_ntc_resistance_hot,
+					 "NTC resistance when hot temperature", NULL),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "charger ntc_temperature cold". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_ntc_temperature_cold,
+			       SHELL_CMD(set, NULL, "Set NTC temperature",
+					 cmd_charger_ntc_temperature_cold_set),
+			       SHELL_CMD(get, NULL, "Get NTC temperature",
+					 cmd_charger_ntc_temperature_cold_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "charger ntc_temperature cool". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_ntc_temperature_cool,
+			       SHELL_CMD(set, NULL, "Set NTC temperature",
+					 cmd_charger_ntc_temperature_cool_set),
+			       SHELL_CMD(get, NULL, "Get NTC temperature",
+					 cmd_charger_ntc_temperature_cool_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "charger ntc_temperature warm". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_ntc_temperature_warm,
+			       SHELL_CMD(set, NULL, "Set NTC temperature",
+					 cmd_charger_ntc_temperature_warm_set),
+			       SHELL_CMD(get, NULL, "Get NTC temperature",
+					 cmd_charger_ntc_temperature_warm_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "charger ntc_temperature hot". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_ntc_temperature_hot,
+			       SHELL_CMD(set, NULL, "Set NTC temperature at hot",
+					 cmd_charger_ntc_temperature_hot_set),
+			       SHELL_CMD(get, NULL, "Get NTC temperature at hot",
+					 cmd_charger_ntc_temperature_hot_get),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 3 command) array for command "charger ntc_temperature". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_ntc_temperature,
+			       SHELL_CMD(cold, &sub_charger_ntc_temperature_cold,
+					 "NTC temperature when cold temperature", NULL),
+			       SHELL_CMD(cool, &sub_charger_ntc_temperature_cool,
+					 "NTC temperature when cool temperature", NULL),
+			       SHELL_CMD(warm, &sub_charger_ntc_temperature_warm,
+					 "NTC temperature when warm temperature", NULL),
+			       SHELL_CMD(hot, &sub_charger_ntc_temperature_hot,
+					 "NTC temperature when hot temperature", NULL),
+			       SHELL_SUBCMD_SET_END);
+
+/* Creating subcommands (level 4 command) array for command "charger status all". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_status_all,
+			       SHELL_CMD(get, NULL, "Get all status", cmd_charger_status_all_get),
 			       SHELL_SUBCMD_SET_END);
 
 /* Creating subcommands (level 4 command) array for command "charger status charging". */
@@ -4249,207 +4237,69 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_status_charging,
 
 /* Creating subcommands (level 3 command) array for command "charger status". */
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_status,
-			       SHELL_CMD(get, NULL, "Get charger status", cmd_charger_status_get),
+			       SHELL_CMD(all, &sub_charger_status_all, "All status", NULL),
 			       SHELL_CMD(charging, &sub_charger_status_charging, "Charging status",
 					 NULL),
 			       SHELL_SUBCMD_SET_END);
 
-/* Creating subcommands (level 4 command) array for command "charger module charger". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_module_charger,
-			       SHELL_CMD(set, NULL, "Enable or disable charging",
-					 cmd_charger_module_charger_set),
-			       SHELL_CMD(get, NULL, "Get charging status",
-					 cmd_charger_module_charger_get),
+/* Creating subcommands (level 3 command) array for command "charger termination_current". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_termination_current,
+			       SHELL_CMD(set, NULL, "Set charger termination current",
+					 cmd_charger_termination_current_set),
+			       SHELL_CMD(get, NULL, "Get charger termination current",
+					 cmd_charger_termination_current_get),
 			       SHELL_SUBCMD_SET_END);
 
-/* Creating subcommands (level 4 command) array for command "charger module recharge". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_module_recharge,
-			       SHELL_CMD(set, NULL, "Enable or disable recharging",
-					 cmd_charger_module_recharge_set),
-			       SHELL_CMD(get, NULL, "Get recharging status",
-					 cmd_charger_module_recharge_get),
+/* Creating subcommands (level 4 command) array for command "charger termination_voltage normal". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_termination_voltage_normal,
+			       SHELL_CMD(set, NULL, "Set charger normal termination voltage",
+					 cmd_charger_termination_voltage_normal_set),
+			       SHELL_CMD(get, NULL, "Get charger normal termination voltage",
+					 cmd_charger_termination_voltage_normal_get),
 			       SHELL_SUBCMD_SET_END);
 
-/* Creating subcommands (level 4 command) array for command "charger module ntc". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_module_ntc,
-			       SHELL_CMD(set, NULL, "Enable or disable NTC",
-					 cmd_charger_module_ntc_set),
-			       SHELL_CMD(get, NULL, "Get NTC status", cmd_charger_module_ntc_get),
+/* Creating subcommands (level 4 command) array for command "charger termination_voltage warm". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_termination_voltage_warm,
+			       SHELL_CMD(set, NULL, "Set charger warm termination voltage",
+					 cmd_charger_termination_voltage_warm_set),
+			       SHELL_CMD(get, NULL, "Get charger warm termination voltage",
+					 cmd_charger_termination_voltage_warm_get),
 			       SHELL_SUBCMD_SET_END);
 
-/* Creating subcommands (level 4 command) array for command "charger module full_cool". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_module_full_cool,
-			       SHELL_CMD(set, NULL, "Enable or disable full charge",
-					 cmd_charger_module_full_cool_set),
-			       SHELL_CMD(get, NULL, "Get full charge status",
-					 cmd_charger_module_full_cool_get),
+/* Creating subcommands (level 3 command) array for command "charger termination_voltage". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_termination_voltage,
+			       SHELL_CMD(normal, &sub_charger_termination_voltage_normal,
+					 "Charger termination voltage normal", NULL),
+			       SHELL_CMD(warm, &sub_charger_termination_voltage_warm,
+					 "Charger termination voltage warm", NULL),
 			       SHELL_SUBCMD_SET_END);
 
-/* Creating subcommands (level 3 command) array for command "charger module". */
-SHELL_STATIC_SUBCMD_SET_CREATE(
-	sub_charger_module, SHELL_CMD(charger, &sub_charger_module_charger, "Charger module", NULL),
-	SHELL_CMD(recharge, &sub_charger_module_recharge, "Recharge module", NULL),
-	SHELL_CMD(ntc, &sub_charger_module_ntc, "NTC module", NULL),
-	SHELL_CMD(full_cool, &sub_charger_module_full_cool, "Full charge in cool temp module",
-		  NULL),
-	SHELL_SUBCMD_SET_END);
-
-/* Creating dictionary subcommands (level 4 command) array for command "charger trickle set". */
-SHELL_SUBCMD_DICT_SET_CREATE(charger_trickle_type, cmd_charger_trickle_set,
-			     (2500, NPMX_CHARGER_TRICKLE_2V5, "2500 mV"),
-			     (2900, NPMX_CHARGER_TRICKLE_2V9, "2900 mV"));
-
-/* Creating subcommands (level 3 command) array for command "charger trickle". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_trickle,
+/* Creating subcommands (level 3 command) array for command "charger trickle_voltage". */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_trickle_voltage,
+			       SHELL_CMD(set, NULL, "Set charger trickle voltage",
+					 cmd_charger_trickle_voltage_set),
 			       SHELL_CMD(get, NULL, "Get charger trickle voltage",
-					 cmd_charger_trickle_get),
-			       SHELL_CMD(set, &charger_trickle_type, "Set charger trickle voltage",
-					 NULL),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 4 command) array for command "charger die_temp resume". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_die_temp_resume,
-			       SHELL_CMD(get, NULL,
-					 "Get die temperature threshold for resuming charging",
-					 cmd_die_temp_resume_get),
-			       SHELL_CMD(set, NULL,
-					 "Set die temperature threshold for resuming charging",
-					 cmd_die_temp_resume_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 4 command) array for command "charger die_temp stop". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_die_temp_stop,
-			       SHELL_CMD(get, NULL,
-					 "Get die temperature threshold for stop charging",
-					 cmd_die_temp_stop_get),
-			       SHELL_CMD(set, NULL,
-					 "Set die temperature threshold for stop charging",
-					 cmd_die_temp_stop_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 4 command) array for command "charger die_temp status". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_die_temp_status,
-			       SHELL_CMD(get, NULL, "Get die temperature comparator status",
-					 cmd_die_temp_status_get),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 3 command) array for command "charger die_temp". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_die_temp,
-			       SHELL_CMD(resume, &sub_die_temp_resume,
-					 "Die temperature threshold where charging resumes", NULL),
-			       SHELL_CMD(stop, &sub_die_temp_stop,
-					 "Die temperature threshold where charging stops", NULL),
-			       SHELL_CMD(status, &sub_die_temp_status,
-					 "Die temperature comparator status", NULL),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 4 command) array for command "charger ntc_resistance cold". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ntc_resistance_cold,
-			       SHELL_CMD(get, NULL, "Get NTC resistance value at 0*C",
-					 cmd_ntc_resistance_cold_get),
-			       SHELL_CMD(set, NULL, "Set NTC resistance value at 0*C",
-					 cmd_ntc_resistance_cold_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 4 command) array for command "charger ntc_resistance cool". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ntc_resistance_cool,
-			       SHELL_CMD(get, NULL, "Get NTC resistance value at 10*C",
-					 cmd_ntc_resistance_cool_get),
-			       SHELL_CMD(set, NULL, "Set NTC resistance value at 10*C",
-					 cmd_ntc_resistance_cool_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 4 command) array for command "charger ntc_resistance warm". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ntc_resistance_warm,
-			       SHELL_CMD(get, NULL, "Get NTC resistance value at 45*C",
-					 cmd_ntc_resistance_warm_get),
-			       SHELL_CMD(set, NULL, "Set NTC resistance value at 45*C",
-					 cmd_ntc_resistance_warm_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 4 command) array for command "charger ntc_resistance hot". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ntc_resistance_hot,
-			       SHELL_CMD(get, NULL, "Get NTC resistance value at 60*C",
-					 cmd_ntc_resistance_hot_get),
-			       SHELL_CMD(set, NULL, "Set NTC resistance value at 60*C",
-					 cmd_ntc_resistance_hot_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 3 command) array for command "charger ntc_resistance". */
-SHELL_STATIC_SUBCMD_SET_CREATE(
-	sub_ntc_resistance,
-	SHELL_CMD(cold, &sub_ntc_resistance_cold, "NTC resistance value at 0*C", NULL),
-	SHELL_CMD(cool, &sub_ntc_resistance_cool, "NTC resistance value at 10*C", NULL),
-	SHELL_CMD(warm, &sub_ntc_resistance_warm, "NTC resistance value at 45*C", NULL),
-	SHELL_CMD(hot, &sub_ntc_resistance_hot, "NTC resistance value at 60*C", NULL),
-	SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 4 command) array for command "charger ntc_temperature cold". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ntc_temperature_cold,
-			       SHELL_CMD(get, NULL, "Get NTC temperature at cold",
-					 cmd_ntc_temperature_cold_get),
-			       SHELL_CMD(set, NULL, "Set NTC temperature at cold",
-					 cmd_ntc_temperature_cold_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 4 command) array for command "charger ntc_temperature cool". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ntc_temperature_cool,
-			       SHELL_CMD(get, NULL, "Get NTC temperature at cool",
-					 cmd_ntc_temperature_cool_get),
-			       SHELL_CMD(set, NULL, "Set NTC temperature at cool",
-					 cmd_ntc_temperature_cool_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 4 command) array for command "charger ntc_temperature warm". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ntc_temperature_warm,
-			       SHELL_CMD(get, NULL, "Get NTC temperature at warm",
-					 cmd_ntc_temperature_warm_get),
-			       SHELL_CMD(set, NULL, "Set NTC temperature at warm",
-					 cmd_ntc_temperature_warm_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 4 command) array for command "charger ntc_temperature hot". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_ntc_temperature_hot,
-			       SHELL_CMD(get, NULL, "Get NTC temperature at hot",
-					 cmd_ntc_temperature_hot_get),
-			       SHELL_CMD(set, NULL, "Set NTC temperature at hot",
-					 cmd_ntc_temperature_hot_set),
-			       SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 3 command) array for command "charger ntc_temperature". */
-SHELL_STATIC_SUBCMD_SET_CREATE(
-	sub_ntc_temperature,
-	SHELL_CMD(cold, &sub_ntc_temperature_cold, "NTC temperature cold", NULL),
-	SHELL_CMD(cool, &sub_ntc_temperature_cool, "NTC temperature cool", NULL),
-	SHELL_CMD(warm, &sub_ntc_temperature_warm, "NTC temperature warm", NULL),
-	SHELL_CMD(hot, &sub_ntc_temperature_hot, "NTC temperature hot", NULL),
-	SHELL_SUBCMD_SET_END);
-
-/* Creating subcommands (level 3 command) array for command "charger discharging_current". */
-SHELL_STATIC_SUBCMD_SET_CREATE(sub_charger_discharging_current,
-			       SHELL_CMD(get, NULL, "Get discharging current",
-					 cmd_charger_discharging_current_get),
-			       SHELL_CMD(set, NULL, "Set discharging current",
-					 cmd_charger_discharging_current_set),
+					 cmd_charger_trickle_voltage_get),
 			       SHELL_SUBCMD_SET_END);
 
 /* Creating subcommands (level 2 command) array for command "charger". */
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_charger,
-	SHELL_CMD(termination_voltage, &sub_charger_termination_voltage,
-		  "Charger termination voltage", NULL),
-	SHELL_CMD(termination_current, &sub_charger_termination_current,
-		  "Charger termination current", NULL),
-	SHELL_CMD(charger_current, &sub_charger_charging_current, "Charger current", NULL),
-	SHELL_CMD(status, &sub_charger_status, "Charger status", NULL),
-	SHELL_CMD(module, &sub_charger_module, "Charger module", NULL),
-	SHELL_CMD(trickle, &sub_charger_trickle, "Charger trickle voltage", NULL),
-	SHELL_CMD(die_temp, &sub_die_temp, "Charger die temperature", NULL),
-	SHELL_CMD(ntc_resistance, &sub_ntc_resistance, "Battery NTC resistance values calibration",
-		  NULL),
-	SHELL_CMD(ntc_temperature, &sub_ntc_temperature, "Battery NTC temperature values", NULL),
+	SHELL_CMD(charging_current, &sub_charger_charging_current, "Charger current", NULL),
+	SHELL_CMD(die_temp, &sub_charger_die_temp, "Charger die temperature", NULL),
 	SHELL_CMD(discharging_current, &sub_charger_discharging_current,
 		  "Maximum discharging current", NULL),
+	SHELL_CMD(module, &sub_charger_module, "Charger module", NULL),
+	SHELL_CMD(ntc_resistance, &sub_charger_ntc_resistance, "Battery NTC resistance values",
+		  NULL),
+	SHELL_CMD(ntc_temperature, &sub_charger_ntc_temperature, "Battery NTC temperature values",
+		  NULL),
+	SHELL_CMD(status, &sub_charger_status, "Charger status", NULL),
+	SHELL_CMD(termination_current, &sub_charger_termination_current,
+		  "Charger termination current", NULL),
+	SHELL_CMD(termination_voltage, &sub_charger_termination_voltage,
+		  "Charger termination voltage", NULL),
+	SHELL_CMD(trickle_voltage, &sub_charger_trickle_voltage, "Charger trickle voltage", NULL),
 	SHELL_SUBCMD_SET_END);
 
 /* Creating dictionary subcommands (level 3 command) array for command "sub_ldsw_mode". */


### PR DESCRIPTION
Command changes:

Main commands:
 - `leds` -> `led`
 
 Charger subcommands:
 - `npmx charger charger_current` -> `npmx charger charging_current`
 - `npmx charger power status` -> `npmx charger status`
 - `npmx charger module ntc` -> `npmx charger module ntc_limits`
 - `npmx charger trickle` -> `npmx charger trickle_voltage` with int voltage as a parameter
 - `npmx charger status get` -> `npmx charger status all get`

LDSW subcommands:
 - `npmx ldsw active_discharge enable` -> `npmx ldsw active_discharge`
 - `npmx ldsw enable_gpio` -> `name ldsw gpio`
 
 Timer subcommands:
 - `npmx timer config period` -> `npmx timer config compare`
  
ADC subcommands:
 - `npmx adc meas take` -> `npmx adc meas`
 
Buck subcommands:
- `npmx buck vout` -> `npmx buck vout_select`
- `npmx buck status power` -> `npmx buck status all`
 
Buck subcommands:
- `npmx gpio debounce` -> `npmx gpio config debounce`
- `npmx gpio drive` -> `npmx gpio config drive`
- `npmx gpio mode` -> `npmx gpio config mode`
- `npmx gpio open_drain` -> `npmx gpio config open_drain`
- `npmx gpio pull` -> `npmx gpio config pull`

Errlog subcommands:
- `npmx errlog check` -> `npmx errlog get`

test:PR-187